### PR TITLE
Added a Catppuccin (inspired) theme.

### DIFF
--- a/themes/catppuccin.json
+++ b/themes/catppuccin.json
@@ -1,0 +1,15 @@
+{
+    "useCustomTheme": true,
+    "DimmedDesc": "#a6adc8",
+    "DimmedTitle": "#a6adc8",
+    "FilteredMatch": "#f38ba8",
+    "NormalTitle": "#f38ba8",
+    "NormalDesc": "#a6e3a1",
+    "SelectedDesc": "#cba6f7",
+    "SelectedTitle": "#cba6f7",
+    "SelectedBorder": "#cba6f7",
+    "SelectedDescBorder": "#cba6f7",
+    "TitleFore": "#cdd6f4",
+    "Titleback": "#1e1e2e",
+    "StatusMsg": "#b4befe"
+}


### PR DESCRIPTION
I have based this Catppuccin-inspired theme on the Mocha variant of Catppuccin.

**Preview w/ Transparency enabled in Hyprland:**
![image](https://github.com/savedra1/clipse/assets/53668025/48f06a00-1189-42f8-a14e-b452a705ce35)

Note: I am not affiliated with the Catppuccin theming project, simply one who enjoys their work.