### PR TITLE
new feat cleanup ref PR #27: removed superfluous `pinned` field from `model` struct

### DIFF
--- a/app/appBase.go
+++ b/app/appBase.go
@@ -107,7 +107,6 @@ type model struct {
 	list         list.Model      // list items
 	keys         *listKeyMap     // keybindings
 	delegateKeys *delegateKeyMap // custom key bindings
-	pinned       bool            // pinned status
 	togglePinned bool
 }
 

--- a/app/appDelegates.go
+++ b/app/appDelegates.go
@@ -144,11 +144,9 @@ func (parentModel *model) newItemDelegate(keys *delegateKeyMap) list.DefaultDele
 				isPinned, err := config.TogglePinClipboardItem(historyFilePath, desc)
 				utils.HandleError(err)
 
-				if parentModel.pinned && isPinned {
-					parentModel.pinned = false
+				if isPinned {
 					return m.NewStatusMessage(statusMessageStyle("UnPinned: " + title))
 				} else if !isPinned {
-					parentModel.pinned = true
 					return m.NewStatusMessage(statusMessageStyle("Pinned: " + title))
 				} else {
 					return m.NewStatusMessage(statusMessageStyle("UnPinned: " + title))


### PR DESCRIPTION
… 'model' struct. missed this in the original PR.