### PR TITLE
Adding configuration capability for clipse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@
 - [Why use clipse?](#why-use-clipse)
 - [Installation](#installation)
 - [Set up](#set-up)
-- [All commands](#all-commands-💻)
-- [How it works](#how-it-works-🤔)
-- [Contributing](#contributing-🙏)
+- [Configuration](#configuration)
+- [All commands](#all-commands-)
+- [How it works](#how-it-works-)
+- [Contributing](#contributing-)
 - [FAQs](#faq)
 
 <br>
@@ -334,6 +335,45 @@ Every system/window manager is different and hard to determine exactly how to ac
 - Run the `clipse -listen` / `clipse --listen-shell` command on startup
 - Bind the `clipse $PPID` command to a key that opens a terminal session (ideally in a window)
 
+## Configuration
+
+Configuration is still quite limited in `clipse`, however this will change as `clipse` evolves and grows. Currently, clipse supports the following configuration:
+- Setting custom paths for:
+  - The clipboard history file
+  - The clipboard binaries directory (copied images and other binary data is stored in here)
+- Providing paths to as many themes as desired (Currently the first one is loaded with no way to change it in code. This might change in the future)
+- Setting a custom max history limit
+- Capability to split the config into multiple files, and referencing each from a base config file
+
+`clipse` looks for a base config file in `$HOME/.config/clipse/config.json`, and creates a default file if it does not find anything. The default config looks like this:
+```json
+{
+    "sources": [
+        "custom_theme.json"
+    ],
+    "maxHistory": 100,
+    "historyFile": "clipboard_history.json",
+    "tempDir": "tmp_files"
+}
+```
+
+Note that all the paths provided (the theme, `historyFile`, and `tempDir`) are all relative paths. They are relative to the location of the config file that holds them. Thus, a file `config.json` at location `$HOME/.config/clipse/config.json` will have all relative paths defined in it relative to its directory of `$HOME/.config/clipse/`.
+
+Absolute paths starting with `/`, paths relative to the user home dir using `~`, or any environment variables like `$HOME` and `$XDG_CONFIG_HOME` are also valid paths.
+
+### Source files
+The `sources` componenet in the config file is powerful, as it allows you to extend configuration by referencing multiple other files in it. 
+Do note that any files loaded this way have to be either a `config` or a `theme` file, with an additional `sourceType` parameter that tells clipse what kind of file it is.
+example:
+```json
+{
+    "sourceType": "config",
+    "sources": []
+}
+```
+
+Any files loaded via this `sources` array will be loaded sequentially. The first file is the least significant and subsequent files are more significant, with the current file (the one that contains the `sources` list) being the most significant. This means if config options are set in multiple source files, the most significant value is used.
+
 ## All commands 💻
 
 `clipse` is more than just a TUI. It also offers a number of CLI commands for managing clipboard content directly from the terminal. 
@@ -399,17 +439,17 @@ The maximum item storage limit is currently hardcoded at **100**. However, there
 ## Contributing 🙏
 
 I would love to receive contributions to this project and welcome PRs from anyone and everyone. The following is a list of example future enhancements I'd like to implement:
-- Image previews in TUI view
-- Customisations for: 
-  - max history limit
-  - config file paths
-  - key bindings
-- System paste option (building functionality to paste the chosen item directly into the next place of focus after the TUI closes)
-- Packages for apt, dnf, brew etc  
-- Theme adjustments made available via CLI 
-- Better debugging
-- Use of a GUI library such as fyne/GIO (only with minimal CPU cost)
-- Cross compile binaries for `wl-clipboard`/`xclip` to remove dependency
+- [ ] Image previews in TUI view
+- [ ] Customisations for: 
+  - [x] ~~max history limit~~
+  - [x] ~~config file paths~~
+  - [ ] key bindings
+- [ ] System paste option (building functionality to paste the chosen item directly into the next place of focus after the TUI closes)
+- [ ] Packages for apt, dnf, brew etc  
+- [ ] Theme adjustments made available via CLI 
+- [ ] Better debugging
+- [ ] Use of a GUI library such as fyne/GIO (only with minimal CPU cost)
+- [ ] Cross compile binaries for `wl-clipboard`/`xclip` to remove dependency
 
 ## FAQ 
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/savedra1/clipse/shell"
+	"github.com/savedra1/clipse/utils"
+)
+
+type Config struct {
+	Sources         []string `json:"sources"`
+	MaxHistory      int      `json:"maxHistory"`
+	HistoryFilePath string   `json:"historyFile"`
+	TempDirPath     string   `json:"tempDir"`
+}
+
+type source struct {
+	SourceType string `json:"sourceType"`
+}
+
+// Global config object, accessed and used when any configuration is needed.
+var ClipseConfig = defaultConfig()
+
+func Init() (string, string, bool, error) {
+	/* Ensure $HOME/.config/clipboard_manager/clipboard_history.json
+	exists and create the path if not. Full path returned as string
+	when successful
+	*/
+	userHome, err := os.UserHomeDir()
+	utils.HandleError(err)
+
+	// Construct the path to the config directory
+	clipseDir := filepath.Join(userHome, ".config", clipseDir) // the ~/.config/clipse dir
+	configPath := filepath.Join(clipseDir, configFile)                    // the path to the config.json file
+
+	// Does Config dir exist, if no make it.
+	_, err = os.Stat(clipseDir)
+	if os.IsNotExist(err) {
+		err = createDir(clipseDir)
+		utils.HandleError(err)
+	}
+
+	// load the config in.
+	loadConfig(configPath)
+
+	// The history path is absolute at this point. Create it if it does not exist
+	initHistoryFile(ClipseConfig.HistoryFilePath)
+
+	// Create TempDir for images if it does not exist.
+	_, err = os.Stat(ClipseConfig.TempDirPath)
+	if os.IsNotExist(err) {
+		err = createDir(ClipseConfig.TempDirPath)
+		utils.HandleError(err)
+	}
+
+	ds := DisplayServer()
+	var ie bool // imagesEnabled?
+	if ds == "unknown" {
+		ie = false
+	} else {
+		ie = shell.ImagesEnabled(ds)
+	}
+
+	return clipseDir, ds, ie, nil
+}
+
+func loadConfig(configPath string) {
+	_, err := os.Stat(configPath)
+	if os.IsNotExist(err) {
+		baseConfig := defaultConfig()
+
+		jsonData, err := json.MarshalIndent(baseConfig, "", "    ")
+		utils.HandleError(err)
+
+		err = os.WriteFile(configPath, jsonData, 0644)
+		if err != nil {
+			fmt.Println("Failed to create:", configPath)
+		}
+	}
+
+	// When recursively calling the sources, we want this source to not be
+	// overwritten. So we store it in this, and at the end set ClipseConfig.
+	//
+	// This means that the last instance is the most signigicant.
+	var tempConfig Config
+
+	configDir := filepath.Dir(configPath)
+
+	confData, err := os.ReadFile(configPath)
+	if err = json.Unmarshal(confData, &tempConfig); err != nil {
+		fmt.Println("Failed to read config. Skipping.\nErr: %w", err)
+	}
+
+	for i := range tempConfig.Sources {
+		// Expand all cases of `~` in source, and call the loadSource func.
+		src := &tempConfig.Sources[i]
+		*src = utils.ExpandRel(utils.ExpandHome(*src), configDir)
+
+		loadSource(*src)
+	}
+
+	// ClipseConfig contains all the settings from all sources. Store sources in temp var.
+	tempConfig.Sources = append(tempConfig.Sources, ClipseConfig.Sources...)
+
+	// All other configs have loaded, load this one.
+	if err = json.Unmarshal(confData, &ClipseConfig); err != nil {
+		fmt.Println("Failed to read config. Skipping.\nErr: %w", err)
+	}
+
+	// Recover source files list.
+	ClipseConfig.Sources = tempConfig.Sources
+
+	// Expand HistoryFile and TempDir paths
+	ClipseConfig.HistoryFilePath = utils.ExpandRel(utils.ExpandHome(ClipseConfig.HistoryFilePath), configDir)
+	ClipseConfig.TempDirPath = utils.ExpandRel(utils.ExpandHome(ClipseConfig.TempDirPath), configDir)
+}
+
+func loadSource(path string) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		fmt.Println("Linked source file not found at:", path)
+		return
+	}
+
+	var src source
+
+	data, err := os.ReadFile(path)
+	if err = json.Unmarshal(data, &src); err != nil {
+		fmt.Printf("Failed to read source at %s. Incorrectly formatted json!\n", path)
+	}
+
+	switch src.SourceType {
+	case "config":
+		loadConfig(path)
+	case "theme":
+		themePaths = append(themePaths, path)
+	case "":
+		fmt.Printf("Error: \"sourceType\" tag not found in source file: %s. File skipped.\n", path)
+		fmt.Println("Possible values for sourceType:\n\t- config\n\t- theme\n\t- history")
+	default:
+		fmt.Printf("Error: Invalid value \"%s\" in \"sourceType\" tag for source file: %s\n",
+			src.SourceType, path)
+		fmt.Println("Possible values for sourceType:\n\t- config\n\t- theme\n\t- history")
+	}
+}

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,12 +1,33 @@
 package config
 
-const (
-	baseDir         = ".config"
-	historyFileName = "clipboard_history.json"
-	themeFile       = "custom_theme.json"
-	clipseDirName   = "clipse"
-	tmpDir          = "tmp_files"
-	listenCmd       = "--listen-shell"
-	maxLen          = 100
-	maxChar         = 65
+import (
+	"os/user"
+	"path/filepath"
+
+	"github.com/savedra1/clipse/utils"
 )
+
+const (
+	baseDir            = ".config"
+	defaultHistoryFile = "clipboard_history.json"
+	defaultThemeFile   = "custom_theme.json"
+	configFile         = "config.json"
+	clipseDir          = "clipse"
+	defaultTempDir     = "tmp_files"
+	listenCmd          = "--listen-shell"
+	defaultMaxHist     = 100
+	maxChar            = 65
+)
+
+// Because Go does not support constant Structs :(
+func defaultConfig() Config {
+	currentUser, err := user.Current()
+	utils.HandleError(err)
+
+	return Config{
+		Sources:         []string{filepath.Join(currentUser.HomeDir, baseDir, clipseDir, defaultThemeFile)},
+		MaxHistory:      defaultMaxHist,
+		HistoryFilePath: defaultHistoryFile,
+		TempDirPath:     defaultTempDir,
+	}
+}

--- a/config/theme.go
+++ b/config/theme.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/savedra1/clipse/utils"
 )
 
 type CustomTheme struct {
@@ -24,12 +26,27 @@ type CustomTheme struct {
 	PinIndicatorColor  string `json:"PinIndicatorColor"`
 }
 
+// For now, reload each time the window is opened. Near future, on file change.
+var themePaths []string
+
 func GetTheme() CustomTheme {
 	/* returns the clipboardHistory array from the
 	clipboard_history.json file
 	*/
-	_, configDir := Paths()
-	fp := filepath.Join(configDir, themeFile)
+
+	// If no themes are specified, create a default theme file and populate it.
+	if len(themePaths) == 0 {
+		homeDir, err := os.UserHomeDir()
+		utils.HandleError(err)
+		defaultThemePath := filepath.Join(homeDir, baseDir, clipseDir, defaultThemeFile)
+
+		initDefaultTheme(defaultThemePath)
+		themePaths = append(themePaths, defaultThemePath)
+	}
+
+	// Just choose the first theme in the list. Change to allow selecting
+	// from multiple themes in the future maybe.
+	fp := themePaths[0]
 
 	file, err := os.OpenFile(fp, os.O_RDONLY, 0644)
 	if err != nil {
@@ -46,7 +63,7 @@ func GetTheme() CustomTheme {
 	return theme
 }
 
-func initTheme(fp string) error {
+func initDefaultTheme(fp string) error {
 	/*
 	  Creates custom_theme.json file is not found in path
 	  and sets base config.

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ var (
 
 func main() {
 	flag.Parse()
-	historyFilePath, clipseDir, imgDir, displayServer, imgEnabled, err := config.Init()
+	clipseDir, displayServer, imgEnabled, err := config.Init()
 	utils.HandleError(err)
 
 	switch {
@@ -54,7 +54,7 @@ func main() {
 		fmt.Println(os.Args[0], version)
 
 	case *add:
-		handleAdd(historyFilePath)
+		handleAdd(config.ClipseConfig.HistoryFilePath)
 
 	case *copy:
 		handleCopy()
@@ -66,13 +66,13 @@ func main() {
 		handleListen()
 
 	case *listenShell:
-		handleListenShell(historyFilePath, clipseDir, displayServer, imgEnabled)
+		handleListenShell(config.ClipseConfig.HistoryFilePath, clipseDir, displayServer, imgEnabled)
 
 	case *kill:
 		handleKill()
 
 	case *clear:
-		handleClear(historyFilePath, imgDir)
+		handleClear(config.ClipseConfig.HistoryFilePath, config.ClipseConfig.TempDirPath)
 
 	case *forceClose:
 		handleForceClose()

--- a/utils/string.go
+++ b/utils/string.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -34,6 +36,37 @@ func GetStdin() string {
 
 func GetTime() string {
 	return strings.TrimSpace(strings.Split(time.Now().UTC().String(), "+0000")[0])
+}
+
+// Expands the path to include the home directory if the path is prefixed
+// with `~`. If it isn't prefixed with `~`, the path is returned as-is.
+func ExpandHome(relPath string) string {
+	if len(relPath) == 0 {
+		return relPath
+	}
+
+	if relPath[0] != '~' {
+		// if not ~, it could be $HOME. Expand that.
+		return os.ExpandEnv(relPath)
+	}
+
+	curUserHome, err := os.UserHomeDir()
+	HandleError(err)
+	
+	return filepath.Join(curUserHome, relPath[1:])
+}
+
+func ExpandRel(relPath, absPath string) string {
+	// Already absolute.
+	if filepath.IsAbs(relPath) {
+		return relPath
+	}
+
+	absRelPath, err := filepath.Abs(filepath.Join(absPath, relPath))
+	if err != nil {
+		fmt.Println("Current working directory is INVALID! How did you manage this?")
+	}
+	return absRelPath
 }
 
 /* NOT IN USE - Remove bad chars - can cause issues with fuzzy finder


### PR DESCRIPTION
Closes #26

### Adds the following capabilities:
- Custom paths for:
  - clipboard history file (default at config dir called `clipboard_history.json`)
  - Temp dir for images and binary data
- Custom max history limit
- Capability to split the config into multiple files

All the paths are relative to the current file. So if a config file in `/a/directory/` defines a `historyFile` in it as `hist.json` then the resulting absolute path used by clipse would be `/a/directory/hist.json`.  Paths can be relative to home using `~` and can have environment variables that are expanded upon importing from the config file.

### Limitations (things this PR can't do/weird behaviours):**
Specify a directory and import all files inside it. This does not support any globing patterns, however that should be easy with the [`filepath.Glob(...)`](https://pkg.go.dev/path/filepath#Glob) function. I can add it if it is wanted.

There is a bit of weird behaviour with themes. Defining anything in the `sources` category in the config file, that file needs a `sourceType` tag in it for the program to know what kind of file it is parsing. So if the theme is at its default location (`$HOME/.config/clipse/custom_theme.json`) and how it currently stands (without a `sourceType`), clipse will complain and skip the file. However, since it is in the default location and if no other theme files are loaded, clipse will fallback on its behaviour before this PR and read the file in the default location. So it leads to that warning being ignorable, and the particular entry in `sources` for the default theme unnecessary (as with the `sourceType` tag in the default theme). 

Idk what to do here. Easiest is obviously to remove it from the default config, but perhaps we could leverage go's forgiving error system and instead try and parse the file as both theme and config, only emitting an error or warning if none of those successfully complete. This would remove the sourceType requirement entirely, but would require a small re-write of the way these files are currently handled (which is not necessarily a bad thing). I would lean towards the latter as it is easier for the user.