### PR TITLE
Feat/multi-select

### DIFF
--- a/app/constants.go
+++ b/app/constants.go
@@ -1,7 +1,7 @@
 package app
 
 const (
-	pinChar         = " "
+	pinChar         = "  "
 	pinColorDefault = "#FF0000"
 	clipboardTitle  = "Clipboard History"
 )

--- a/app/delegate.go
+++ b/app/delegate.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,7 +11,13 @@ import (
 	"github.com/savedra1/clipse/config"
 )
 
-// Delegate used to override individual item appearance based on state.
+func (m *model) newItemDelegate() itemDelegate {
+	return itemDelegate{
+		theme: m.theme,
+	}
+}
+
+// delegate used to override individual item appearance based on state
 
 type itemDelegate struct {
 	theme config.CustomTheme
@@ -19,6 +26,7 @@ type itemDelegate struct {
 func (d itemDelegate) Height() int                               { return 2 }
 func (d itemDelegate) Spacing() int                              { return 1 }
 func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
+
 func (d itemDelegate) Render(
 	w io.Writer,
 	m list.Model,
@@ -33,19 +41,26 @@ func (d itemDelegate) Render(
 	var renderStr string
 
 	switch {
-	case m.FilterState() == list.Filtering:
-		renderStr = d.itemFilterStyle(i, m)
-	case i.selected, index == m.Index():
-		renderStr = d.itemSelectedStyle(i, m, index)
+
+	case m.SettingFilter():
+		if strings.Contains(
+			strings.ToLower(i.titleFull),
+			strings.ToLower(m.FilterValue()),
+		) && m.FilterValue() != "" {
+			renderStr = d.itemSelectedStyle(i)
+		} else {
+			renderStr = d.itemFilterStyle(i)
+		}
+
+	case index == m.Index():
+		renderStr = d.itemChosenStyle(i)
+
+	case i.selected:
+		renderStr = d.itemSelectedStyle(i)
+
 	default:
 		renderStr = d.itemNormalStyle(i)
 	}
 
 	fmt.Fprint(w, renderStr)
-}
-
-func (m *model) newItemDelegate() itemDelegate {
-	return itemDelegate{
-		theme: m.theme,
-	}
 }

--- a/app/delegate.go
+++ b/app/delegate.go
@@ -19,8 +19,12 @@ type itemDelegate struct {
 func (d itemDelegate) Height() int                               { return 2 }
 func (d itemDelegate) Spacing() int                              { return 1 }
 func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
-
-func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+func (d itemDelegate) Render(
+	w io.Writer,
+	m list.Model,
+	index int,
+	listItem list.Item,
+) {
 	i, ok := listItem.(item)
 	if !ok {
 		return

--- a/app/delegate.go
+++ b/app/delegate.go
@@ -28,14 +28,14 @@ func (parentModel *model) newItemDelegate(keys *keyMap) list.DefaultDelegate {
 		var fp string
 		var desc string
 
-		i, ok := m.SelectedItem().(item)
+		item, ok := m.SelectedItem().(item)
 		if !ok {
 			return nil
 		}
-		title = i.Title()
-		fullValue = i.TitleFull()
-		fp = i.FilePath()
-		desc = i.TimeStamp()
+		title = item.Title()
+		fullValue = item.TitleFull()
+		fp = item.FilePath()
+		desc = item.TimeStamp()
 
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
@@ -73,7 +73,7 @@ func (parentModel *model) newItemDelegate(keys *keyMap) list.DefaultDelegate {
 					if currentContent == fullValue {
 						clipboard.WriteAll("")
 					}
-					err := config.DeleteJsonItem(desc) // This func will also delete the temoraily stored image if filepath present
+					err := config.DeleteJsonItem(desc)
 					utils.HandleError(err)
 				}()
 
@@ -107,7 +107,7 @@ func (parentModel *model) newItemDelegate(keys *keyMap) list.DefaultDelegate {
 				}
 
 				clipboardItems := config.GetHistory()
-				filteredItems := filterItems(clipboardItems, parentModel.togglePinned)
+				filteredItems := filterItems(clipboardItems, parentModel.togglePinned, parentModel.theme)
 
 				if len(filteredItems) == 0 {
 					m.Title = clipboardTitle
@@ -120,6 +120,12 @@ func (parentModel *model) newItemDelegate(keys *keyMap) list.DefaultDelegate {
 				for _, item := range filteredItems { // adds all required items
 					m.InsertItem(len(m.Items()), item)
 				}
+				//switch msg.String() {
+				//case "y":
+				//	allItems := m.Items()
+				//	fmt.Println(allItems)
+				//}
+
 			}
 		}
 		return nil

--- a/app/keys.go
+++ b/app/keys.go
@@ -15,6 +15,7 @@ type keyMap struct {
 	togglePinned key.Binding
 	selectDown   key.Binding
 	selectUp     key.Binding
+	selectSingle key.Binding
 }
 
 func newKeyMap() *keyMap {
@@ -48,19 +49,23 @@ func newKeyMap() *keyMap {
 			key.WithHelp("↹", "show pinned"),
 		),
 		selectDown: key.NewBinding(
-			key.WithKeys("shift+down"),
+			key.WithKeys("shift+down", "J"),
 			key.WithHelp("⇧+↓/↑", "select"),
 		),
 		selectUp: key.NewBinding(
-			key.WithKeys("shift+up"),
+			key.WithKeys("shift+up", "K"),
 			key.WithHelp("⇧+↓/↑", "select"),
+		),
+		selectSingle: key.NewBinding(
+			key.WithKeys("S"),
+			key.WithHelp("S", "select single"),
 		),
 	}
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
-		k.choose, k.remove, k.filter, k.togglePin, k.togglePinned, k.more,
+		k.choose, k.remove, k.togglePin, k.togglePinned, k.more,
 	}
 }
 

--- a/app/keys.go
+++ b/app/keys.go
@@ -4,13 +4,6 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 )
 
-func (i item) Title() string       { return i.title }
-func (i item) TitleFull() string   { return i.titleFull }
-func (i item) TimeStamp() string   { return i.timeStamp }
-func (i item) Description() string { return i.description }
-func (i item) FilePath() string    { return i.filePath }
-func (i item) FilterValue() string { return i.title }
-
 // default keybind definitions
 type keyMap struct {
 	filter       key.Binding

--- a/app/keys.go
+++ b/app/keys.go
@@ -6,22 +6,23 @@ import (
 
 // default keybind definitions
 type keyMap struct {
-	filter       key.Binding
-	quit         key.Binding
-	more         key.Binding
-	choose       key.Binding
-	remove       key.Binding
-	togglePin    key.Binding
-	togglePinned key.Binding
-	selectDown   key.Binding
-	selectUp     key.Binding
-	selectSingle key.Binding
-	up           key.Binding
-	down         key.Binding
-	nextPage     key.Binding
-	prevPage     key.Binding
-	home         key.Binding
-	end          key.Binding
+	filter        key.Binding
+	quit          key.Binding
+	more          key.Binding
+	choose        key.Binding
+	remove        key.Binding
+	togglePin     key.Binding
+	togglePinned  key.Binding
+	selectDown    key.Binding
+	selectUp      key.Binding
+	selectSingle  key.Binding
+	clearSelected key.Binding
+	up            key.Binding
+	down          key.Binding
+	nextPage      key.Binding
+	prevPage      key.Binding
+	home          key.Binding
+	end           key.Binding
 }
 
 func newKeyMap() *keyMap {
@@ -63,8 +64,12 @@ func newKeyMap() *keyMap {
 			key.WithHelp("⇧+↓/↑", "select"),
 		),
 		selectSingle: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "select single"),
+		),
+		clearSelected: key.NewBinding(
 			key.WithKeys("S"),
-			key.WithHelp("S", "select single"),
+			key.WithHelp("S", "clear selected"),
 		),
 		up: key.NewBinding(
 			key.WithKeys("up", "k"),

--- a/app/keys.go
+++ b/app/keys.go
@@ -20,6 +20,8 @@ type keyMap struct {
 	remove       key.Binding
 	togglePin    key.Binding
 	togglePinned key.Binding
+	selectDown   key.Binding
+	selectUp     key.Binding
 }
 
 func newKeyMap() *keyMap {
@@ -51,6 +53,14 @@ func newKeyMap() *keyMap {
 		togglePinned: key.NewBinding(
 			key.WithKeys("tab"),
 			key.WithHelp("↹", "show pinned"),
+		),
+		selectDown: key.NewBinding(
+			key.WithKeys("shift+down"),
+			key.WithHelp("⇧+↓/↑", "select"),
+		),
+		selectUp: key.NewBinding(
+			key.WithKeys("shift+up"),
+			key.WithHelp("⇧+↓/↑", "select"),
 		),
 	}
 }

--- a/app/keys.go
+++ b/app/keys.go
@@ -108,14 +108,19 @@ func (k keyMap) ShortHelp() []key.Binding {
 	}
 }
 
+// not currently in use as intentionally being overridden by the default
+// full help view
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
+		{k.up, k.down, k.home, k.end},
 		{k.choose, k.remove},
 		{k.togglePin, k.togglePinned},
+		{k.selectDown, k.selectSingle, k.yankFilter},
 		{k.filter, k.quit},
 	}
 }
 
+// used only for the default filter input view
 type filterKeyMap struct {
 	apply       key.Binding
 	cancel      key.Binding

--- a/app/keys.go
+++ b/app/keys.go
@@ -16,6 +16,12 @@ type keyMap struct {
 	selectDown   key.Binding
 	selectUp     key.Binding
 	selectSingle key.Binding
+	up           key.Binding
+	down         key.Binding
+	nextPage     key.Binding
+	prevPage     key.Binding
+	home         key.Binding
+	end          key.Binding
 }
 
 func newKeyMap() *keyMap {
@@ -59,6 +65,24 @@ func newKeyMap() *keyMap {
 		selectSingle: key.NewBinding(
 			key.WithKeys("S"),
 			key.WithHelp("S", "select single"),
+		),
+		up: key.NewBinding(
+			key.WithKeys("up", "k"),
+		),
+		down: key.NewBinding(
+			key.WithKeys("down", "j"),
+		),
+		nextPage: key.NewBinding(
+			key.WithKeys("right", "l"),
+		),
+		prevPage: key.NewBinding(
+			key.WithKeys("left", "h"),
+		),
+		home: key.NewBinding(
+			key.WithKeys("home", "g"),
+		),
+		end: key.NewBinding(
+			key.WithKeys("end", "G"),
 		),
 	}
 }

--- a/app/keys.go
+++ b/app/keys.go
@@ -17,6 +17,8 @@ type keyMap struct {
 	selectUp      key.Binding
 	selectSingle  key.Binding
 	clearSelected key.Binding
+	fuzzySelect   key.Binding
+	yankFilter    key.Binding
 	up            key.Binding
 	down          key.Binding
 	nextPage      key.Binding
@@ -56,12 +58,12 @@ func newKeyMap() *keyMap {
 			key.WithHelp("↹", "show pinned"),
 		),
 		selectDown: key.NewBinding(
-			key.WithKeys("shift+down", "J"),
-			key.WithHelp("⇧+↓/↑", "select"),
+			key.WithKeys("ctrl+down", "ctrl+j"),
+			key.WithHelp("ctrl+↓/↑", "select"),
 		),
 		selectUp: key.NewBinding(
-			key.WithKeys("shift+up", "K"),
-			key.WithHelp("⇧+↓/↑", "select"),
+			key.WithKeys("ctrl+up", "ctrl+k"),
+			key.WithHelp("ctrl+↓/↑", "select"),
 		),
 		selectSingle: key.NewBinding(
 			key.WithKeys("s"),
@@ -70,6 +72,14 @@ func newKeyMap() *keyMap {
 		clearSelected: key.NewBinding(
 			key.WithKeys("S"),
 			key.WithHelp("S", "clear selected"),
+		),
+		fuzzySelect: key.NewBinding(
+			key.WithKeys("F"),
+			key.WithHelp("F", "select search"),
+		),
+		yankFilter: key.NewBinding(
+			key.WithKeys("ctrl+s"),
+			key.WithHelp("ctrl+s", "yank filter results"),
 		),
 		up: key.NewBinding(
 			key.WithKeys("up", "k"),
@@ -107,8 +117,9 @@ func (k keyMap) FullHelp() [][]key.Binding {
 }
 
 type filterKeyMap struct {
-	apply  key.Binding
-	cancel key.Binding
+	apply       key.Binding
+	cancel      key.Binding
+	yankMatches key.Binding
 }
 
 func newFilterKeymap() *filterKeyMap {
@@ -121,11 +132,15 @@ func newFilterKeymap() *filterKeyMap {
 			key.WithKeys("esc"),
 			key.WithHelp("esc", "cancel"),
 		),
+		yankMatches: key.NewBinding(
+			key.WithKeys("ctrl+s"),
+			key.WithHelp("ctrl+s", "yank matched"),
+		),
 	}
 }
 
 func (fk filterKeyMap) FilterHelp() []key.Binding {
 	return []key.Binding{
-		fk.apply, fk.cancel,
+		fk.apply, fk.cancel, fk.yankMatches,
 	}
 }

--- a/app/model.go
+++ b/app/model.go
@@ -72,9 +72,7 @@ func NewModel() model {
 	del := m.newItemDelegate()
 
 	clipboardList := list.New(entryItems, del, 0, 0)
-	clipboardList.Title = clipboardTitle // set hardcoded title
-	clipboardList.SetShowTitle(true)
-	clipboardList.SetShowStatusBar(true)
+	clipboardList.Title = clipboardTitle                                       // set hardcoded title
 	clipboardList.SetShowHelp(false)                                           // override with custom
 	clipboardList.Styles.PaginationStyle = style.MarginBottom(1).MarginLeft(2) // set custom pagination spacing
 	//clipboardList.StatusMessageLifetime = time.Second // can override this if necessary

--- a/app/model.go
+++ b/app/model.go
@@ -89,6 +89,7 @@ func NewModel() model {
 		return []key.Binding{
 			listKeys.selectDown,
 			listKeys.selectSingle,
+			listKeys.clearSelected,
 		}
 	}
 

--- a/app/model.go
+++ b/app/model.go
@@ -20,12 +20,14 @@ var (
 )
 
 type model struct {
-	list         list.Model         // list items
-	keys         *keyMap            // keybindings
-	filterKeys   *filterKeyMap      // keybindings for filter view
-	help         help.Model         // custom help menu
-	togglePinned bool               // pinned view indicator
-	theme        config.CustomTheme // colors scheme to uses
+	list          list.Model         // list items
+	keys          *keyMap            // keybindings
+	filterKeys    *filterKeyMap      // keybindings for filter view
+	help          help.Model         // custom help menu
+	togglePinned  bool               // pinned view indicator
+	theme         config.CustomTheme // colors scheme to uses
+	prevDirection string             // prev direction used to track selections
+	selections    []int              // indexes of selected items
 }
 
 type item struct {
@@ -61,11 +63,13 @@ func NewModel() model {
 
 	// instantiate model
 	m := model{
-		keys:         listKeys,
-		filterKeys:   filterKeys,
-		help:         help.New(),
-		togglePinned: false,
-		theme:        ct,
+		keys:          listKeys,
+		filterKeys:    filterKeys,
+		help:          help.New(),
+		togglePinned:  false,
+		theme:         ct,
+		prevDirection: "",
+		selections:    []int{},
 	}
 
 	entryItems := filterItems(clipboardItems, false, m.theme)

--- a/app/model.go
+++ b/app/model.go
@@ -27,7 +27,6 @@ type model struct {
 	togglePinned  bool               // pinned view indicator
 	theme         config.CustomTheme // colors scheme to uses
 	prevDirection string             // prev direction used to track selections
-	selections    []int              // indexes of selected items
 }
 
 type item struct {
@@ -55,13 +54,10 @@ func NewModel() model {
 		filterKeys = newFilterKeymap()
 	)
 
-	// get initial list of items
 	clipboardItems := config.GetHistory()
 
-	// get theme info
 	ct := config.GetTheme()
 
-	// instantiate model
 	m := model{
 		keys:          listKeys,
 		filterKeys:    filterKeys,
@@ -69,15 +65,12 @@ func NewModel() model {
 		togglePinned:  false,
 		theme:         ct,
 		prevDirection: "",
-		selections:    []int{},
 	}
 
 	entryItems := filterItems(clipboardItems, false, m.theme)
 
-	// instantiate model delegate
 	del := m.newItemDelegate()
 
-	// create list.Model object
 	clipboardList := list.New(entryItems, del, 0, 0)
 	clipboardList.Title = clipboardTitle // set hardcoded title
 	clipboardList.SetShowTitle(true)

--- a/app/styles.go
+++ b/app/styles.go
@@ -7,6 +7,22 @@ import (
 	"github.com/savedra1/clipse/config"
 )
 
+func updateSelectionStyle(item item, theme config.CustomTheme) item {
+	desc := item.descriptionBase
+	if item.pinned {
+		desc = desc + " " + styledPin(theme)
+	}
+
+	if !item.selected {
+		item.title = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.NormalTitle)).Render(item.titleBase)
+		item.description = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.NormalDesc)).Render(desc)
+	} else {
+		item.title = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.SelectedTitle)).Render(item.titleBase)
+		item.description = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.SelectedDesc)).Render(desc)
+	}
+	return item
+}
+
 func setDefaultStyling(clipboardList list.Model) list.Model {
 	// align list elements
 	clipboardList.FilterInput.PromptStyle = lipgloss.NewStyle().PaddingTop(1)
@@ -33,6 +49,7 @@ func styledDelegate(del list.DefaultDelegate, ct config.CustomTheme) list.Defaul
 	del.Styles.SelectedDesc = del.Styles.SelectedDesc.
 		Foreground(lipgloss.Color(ct.SelectedDesc)).
 		BorderForeground(lipgloss.Color(ct.SelectedDescBorder))
+
 	del.Styles.SelectedTitle = del.Styles.SelectedTitle.
 		Foreground(lipgloss.Color(ct.SelectedTitle)).
 		BorderForeground(lipgloss.Color(ct.SelectedBorder))
@@ -88,13 +105,7 @@ func styledStatusMessage(ct config.CustomTheme) func(strs ...string) string {
 		Render
 }
 
-func styledPin() string {
-	theme := config.GetTheme()
-	if theme.UseCustom {
-		return lipgloss.NewStyle().
-			Foreground(lipgloss.Color(theme.PinIndicatorColor)).Render(pinChar)
-	}
+func styledPin(theme config.CustomTheme) string {
 	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color(pinColorDefault)).Render(pinChar)
-
+		Foreground(lipgloss.Color(theme.PinIndicatorColor)).Render(pinChar)
 }

--- a/app/styles.go
+++ b/app/styles.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/list"
@@ -25,7 +24,7 @@ func setDefaultStyling(clipboardList list.Model) list.Model {
 	return clipboardList
 }
 
-func (d itemDelegate) itemFilterStyle(i item, m list.Model) string {
+func (d itemDelegate) itemFilterStyle(i item) string {
 	titleStyle := style.
 		Foreground(lipgloss.Color(d.theme.DimmedTitle)).
 		PaddingLeft(2).
@@ -36,50 +35,42 @@ func (d itemDelegate) itemFilterStyle(i item, m list.Model) string {
 		PaddingLeft(2).
 		Render(i.descriptionBase)
 
-	if strings.Contains(
-		strings.ToLower(i.FilterValue()),
-		strings.ToLower(m.FilterValue()),
-	) && m.FilterValue() != "" {
-		titleStyle = style.
-			Foreground(lipgloss.Color(d.theme.NormalTitle)).
-			PaddingLeft(2).
-			Render(i.titleBase)
-
-		descStyle = style.
-			Foreground(lipgloss.Color(d.theme.NormalDesc)).
-			PaddingLeft(2).
-			Render(i.descriptionBase)
-	}
 	return fmt.Sprintf("%s\n%s", titleStyle, descStyle)
 }
 
-func (d itemDelegate) itemSelectedStyle(i item, m list.Model, index int) string {
+func (d itemDelegate) itemChosenStyle(i item) string {
+	titleStyle = style.
+		Foreground(lipgloss.Color(d.theme.SelectedTitle)).
+		PaddingLeft(1).
+		BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color(d.theme.SelectedDescBorder)).
+		Render(i.titleBase)
 
-	if index == m.Index() {
-		titleStyle = style.
-			Foreground(lipgloss.Color(d.theme.SelectedTitle)).
-			PaddingLeft(1).
-			BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).
-			BorderForeground(lipgloss.Color(d.theme.SelectedDescBorder)).
-			Render(i.titleBase)
+	descStyle = style.
+		Foreground(lipgloss.Color(d.theme.SelectedDesc)).
+		PaddingLeft(1).
+		BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color(d.theme.SelectedDescBorder)).
+		Render(i.descriptionBase)
 
-		descStyle = style.
-			Foreground(lipgloss.Color(d.theme.SelectedDesc)).
-			PaddingLeft(1).
-			BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).
-			BorderForeground(lipgloss.Color(d.theme.SelectedDescBorder)).
-			Render(i.descriptionBase)
-	} else {
-		titleStyle = style.
-			Foreground(lipgloss.Color(d.theme.SelectedTitle)).
-			PaddingLeft(2).
-			Render(i.titleBase)
-
-		descStyle = style.
-			Foreground(lipgloss.Color(d.theme.SelectedDesc)).
-			PaddingLeft(2).
-			Render(i.descriptionBase)
+	if i.pinned {
+		descStyle = descStyle + " " + styledPin(d.theme)
 	}
+
+	return fmt.Sprintf("%s\n%s", titleStyle, descStyle)
+}
+
+func (d itemDelegate) itemSelectedStyle(i item) string {
+
+	titleStyle = style.
+		Foreground(lipgloss.Color(d.theme.SelectedTitle)).
+		PaddingLeft(2).
+		Render(i.titleBase)
+
+	descStyle = style.
+		Foreground(lipgloss.Color(d.theme.SelectedDesc)).
+		PaddingLeft(2).
+		Render(i.descriptionBase)
 
 	if i.pinned {
 		descStyle = descStyle + " " + styledPin(d.theme)

--- a/app/styles.go
+++ b/app/styles.go
@@ -89,12 +89,12 @@ func (d itemDelegate) itemSelectedStyle(i item, m list.Model, index int) string 
 }
 
 func (d itemDelegate) itemNormalStyle(i item) string {
-	titleStyle := style.
+	titleStyle = style.
 		Foreground(lipgloss.Color(d.theme.NormalTitle)).
 		PaddingLeft(2).
 		Render(i.titleBase)
 
-	descStyle := style.
+	descStyle = style.
 		Foreground(lipgloss.Color(d.theme.NormalDesc)).
 		PaddingLeft(2).
 		Render(i.descriptionBase)

--- a/app/styles.go
+++ b/app/styles.go
@@ -54,7 +54,7 @@ func (d itemDelegate) itemChosenStyle(i item) string {
 		Render(i.descriptionBase)
 
 	if i.pinned {
-		descStyle = descStyle + " " + styledPin(d.theme)
+		descStyle += styledPin(d.theme)
 	}
 
 	return fmt.Sprintf("%s\n%s", titleStyle, descStyle)
@@ -73,7 +73,7 @@ func (d itemDelegate) itemSelectedStyle(i item) string {
 		Render(i.descriptionBase)
 
 	if i.pinned {
-		descStyle = descStyle + " " + styledPin(d.theme)
+		descStyle += styledPin(d.theme)
 	}
 
 	return fmt.Sprintf("%s\n%s", titleStyle, descStyle)
@@ -91,7 +91,7 @@ func (d itemDelegate) itemNormalStyle(i item) string {
 		Render(i.descriptionBase)
 
 	if i.pinned {
-		descStyle = descStyle + " " + styledPin(d.theme)
+		descStyle += styledPin(d.theme)
 	}
 
 	return fmt.Sprintf("%s\n%s", titleStyle, descStyle)

--- a/app/styles.go
+++ b/app/styles.go
@@ -54,6 +54,7 @@ func (d itemDelegate) itemFilterStyle(i item, m list.Model) string {
 }
 
 func (d itemDelegate) itemSelectedStyle(i item, m list.Model, index int) string {
+
 	if index == m.Index() {
 		titleStyle = style.
 			Foreground(lipgloss.Color(d.theme.SelectedTitle)).
@@ -180,5 +181,6 @@ func styledStatusMessage(ct config.CustomTheme) func(strs ...string) string {
 
 func styledPin(theme config.CustomTheme) string {
 	return style.
-		Foreground(lipgloss.Color(theme.PinIndicatorColor)).Render(pinChar)
+		Foreground(lipgloss.Color(theme.PinIndicatorColor)).
+		Render(pinChar)
 }

--- a/app/update.go
+++ b/app/update.go
@@ -25,8 +25,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		if m.list.SettingFilter() && key.Matches(msg, m.keys.yankFilter) {
-			//filterValue := m.list.FilterValue()
-
 			filterMatches := m.filterMatches()
 			if len(filterMatches) >= 1 {
 				err := clipboard.WriteAll(strings.Join(filterMatches, "\n"))
@@ -65,49 +63,69 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.keys.choose):
 			selectedItems := m.selectedItems()
-			if len(selectedItems) < 1 && fp == "null" {
-				err := clipboard.WriteAll(fullValue)
-				utils.HandleError(err)
-				return m, tea.Quit
+
+			if len(selectedItems) < 1 {
+				switch {
+				case fp != "null":
+					ds := config.DisplayServer() // eg "wayland"
+					utils.HandleError(shell.CopyImage(fp, ds))
+					return m, tea.Quit
+
+				case len(os.Args) > 2 && utils.IsInt(os.Args[2]):
+					shell.KillProcess(os.Args[2])
+					return m, tea.Quit
+
+				case len(os.Args) > 1 && os.Args[1] == "keep":
+					utils.HandleError(clipboard.WriteAll(fullValue))
+					cmds = append(
+						cmds,
+						m.list.NewStatusMessage(statusMessageStyle("Copied to clipboard: "+title)),
+					)
+					return m, tea.Batch(cmds...)
+
+				default:
+					err := clipboard.WriteAll(fullValue)
+					utils.HandleError(err)
+					return m, tea.Quit
+				}
 			}
 
-			if len(selectedItems) >= 1 {
-				yank := ""
-				for _, item := range selectedItems {
-					if fullValue != item.Value {
-						yank += item.Value + "\n"
-					}
+			yank := ""
+			for _, item := range selectedItems {
+				if fullValue != item.Value {
+					yank += item.Value + "\n"
 				}
-				yank += fullValue
+			}
+			yank += fullValue
+			switch {
+
+			case len(os.Args) > 2 && utils.IsInt(os.Args[2]):
+				utils.HandleError(clipboard.WriteAll(yank))
+				shell.KillProcess(os.Args[2])
+				return m, tea.Quit
+
+			case len(os.Args) > 1 && os.Args[1] == "keep":
+				statusMsg := "Copied to clipboard: *selected items*"
+				err := clipboard.WriteAll(yank)
+				if err != nil {
+					statusMsg = "Could not copy all selected items."
+				}
+				cmds = append(
+					cmds,
+					m.list.NewStatusMessage(statusMessageStyle(statusMsg)),
+				)
+				return m, tea.Batch(cmds...)
+
+			default:
 				err := clipboard.WriteAll(yank)
 				if err == nil {
 					return m, tea.Quit
 				}
 				cmds = append(
 					cmds,
-					m.list.NewStatusMessage(statusMessageStyle("Failed to copy all selected items.")),
+					m.list.NewStatusMessage(statusMessageStyle("Could not copy all selected items.")),
 				)
-			}
 
-			if fp != "null" {
-				ds := config.DisplayServer() // eg "wayland"
-				err := shell.CopyImage(fp, ds)
-				utils.HandleError(err)
-				return m, tea.Quit
-			}
-
-			if len(os.Args) > 2 {
-				if utils.IsInt(os.Args[2]) {
-					shell.KillProcess(os.Args[2])
-					return m, tea.Quit
-				}
-			} else if len(os.Args) > 1 {
-				if os.Args[1] == "keep" {
-					cmds = append(
-						cmds,
-						m.list.NewStatusMessage(statusMessageStyle("Copied to clipboard: "+title)),
-					)
-				}
 			}
 
 		case key.Matches(msg, m.keys.remove):
@@ -115,13 +133,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			currentIndex := m.list.Index()
 
 			currentContent, _ := clipboard.ReadAll()
-			if currentContent == fullValue {
-				clipboard.WriteAll("")
-			} else {
-				for _, item := range selectedItems {
-					if item.Value == currentContent {
-						clipboard.WriteAll("")
-					}
+
+			for _, item := range selectedItems {
+				if item.Value == currentContent {
+					clipboard.WriteAll("") // clear clipboard to stop deleted content temp repopulating (temp solution)
 				}
 			}
 
@@ -130,7 +145,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(selectedItems) >= 1 {
 				timeStamps := []string{}
 				m.list.RemoveItem(currentIndex)
-				m.removeSelected()
+				m.removeMultiSelected()
 				for _, item := range selectedItems {
 					timeStamps = append(timeStamps, strings.Split(item.Description, "Date copied: ")[1])
 				}
@@ -180,11 +195,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.keys.togglePinned.SetEnabled(false)
 			}
 			m.togglePinned = !m.togglePinned
+			m.list.Title = clipboardTitle
 			if m.togglePinned {
 				m.list.Title = "Pinned " + clipboardTitle
-			} else {
-				m.list.Title = clipboardTitle
 			}
+
 			clipboardItems := config.GetHistory()
 			filteredItems := filterItems(clipboardItems, m.togglePinned, m.theme)
 
@@ -233,7 +248,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case key.Matches(msg, m.keys.clearSelected), key.Matches(msg, m.keys.filter):
-			m.clearSelected()
+			m.resetSelected()
 
 		case key.Matches(msg, m.keys.yankFilter):
 			cmds = append(
@@ -312,7 +327,6 @@ func (m *model) toggleSelected(direction string) {
 		return
 	}
 
-	//index := m.list.Index()
 	index := m.list.Index()
 
 	if item.selected {
@@ -363,7 +377,7 @@ func (m *model) selectedItems() []SelectedItem {
 }
 
 // iterate over the list items backwards so the indexes are not affected
-func (m *model) removeSelected() {
+func (m *model) removeMultiSelected() {
 	items := m.list.Items()
 	for i := len(items) - 1; i >= 0; i-- {
 		if item, ok := items[i].(item); ok && item.selected {
@@ -373,7 +387,7 @@ func (m *model) removeSelected() {
 }
 
 // remove selected state from all items
-func (m *model) clearSelected() {
+func (m *model) resetSelected() {
 	items := m.list.Items()
 	for i := len(items) - 1; i >= 0; i-- {
 		if item, ok := items[i].(item); ok && item.selected {
@@ -387,14 +401,17 @@ func (m *model) clearSelected() {
 func (m *model) filterMatches() []string {
 	filteredItems := []string{}
 	for _, i := range m.list.Items() {
-		if item, ok := i.(item); ok {
-			if strings.Contains(
-				strings.ToLower(item.titleFull),
-				strings.ToLower(m.list.FilterValue()),
-			) {
-				filteredItems = append(filteredItems, item.titleFull)
-			}
+		item, ok := i.(item)
+		if !ok {
+			continue
+		}
+		if strings.Contains(
+			strings.ToLower(item.titleFull),
+			strings.ToLower(m.list.FilterValue()),
+		) {
+			filteredItems = append(filteredItems, item.titleFull)
 		}
 	}
+
 	return filteredItems
 }

--- a/app/update.go
+++ b/app/update.go
@@ -14,8 +14,12 @@ import (
 	"github.com/savedra1/clipse/utils"
 )
 
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+/*
+	The main update function used to handle core TUI logic and update
+	the model state.
+*/
 
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
@@ -24,6 +28,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.list.SetSize(msg.Width-h, msg.Height-v)
 
 	case tea.KeyMsg:
+		if key.Matches(msg, m.keys.filter) && m.list.ShowHelp() {
+			m.list.Help.ShowAll = false // change default back to short help to keep in sync
+			m.list.SetShowHelp(false)
+			m.updatePaginator()
+		}
+
 		if m.list.SettingFilter() && key.Matches(msg, m.keys.yankFilter) {
 			filterMatches := m.filterMatches()
 			if len(filterMatches) >= 1 {
@@ -46,13 +56,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		i, ok := m.list.SelectedItem().(item)
 		if !ok {
+
 			switch {
 			case key.Matches(msg, m.keys.more):
 				m.list.SetShowHelp(!m.list.ShowHelp())
 				m.updatePaginator()
 			}
 			break
-
 		}
 		title := i.Title()
 		fullValue := i.TitleFull()
@@ -136,7 +146,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			for _, item := range selectedItems {
 				if item.Value == currentContent {
-					clipboard.WriteAll("") // clear clipboard to stop deleted content temp repopulating (temp solution)
+					// clear clipboard to stop deleted content temp repopulating (temp solution)
+					clipboard.WriteAll("")
 				}
 			}
 
@@ -174,7 +185,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.list.Items()) == 0 {
 				m.keys.togglePin.SetEnabled(false)
 			}
-			// update pinned status in history file
 			isPinned, err := config.TogglePinClipboardItem(desc)
 			utils.HandleError(err)
 			m.togglePinUpdate()

--- a/app/update.go
+++ b/app/update.go
@@ -1,11 +1,8 @@
 /*
 	TODO
-	- fix for items not showing selected after selection was set
-	- fix for selected item styles not updating during filter view
 	- implement final behaviour for multi-selection:
 		- directional unselect
 		- selection of next item
-	- update help menu
 	- implement logic to copy all selected split by a configurable custom string val
 */
 
@@ -13,10 +10,16 @@ package app
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/savedra1/clipse/config"
+	"github.com/savedra1/clipse/shell"
+	"github.com/savedra1/clipse/utils"
 )
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -33,18 +36,119 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			//m.resetSelected() - need to implement
 			break
 		}
-		switch msg.String() {
-		case "p":
+		item, ok := m.list.SelectedItem().(item)
+		if !ok {
+			return nil, nil
+		}
+		title := item.Title()
+		fullValue := item.TitleFull()
+		fp := item.FilePath()
+		desc := item.TimeStamp()
+		switch {
+		case key.Matches(msg, m.keys.choose):
+			if fp != "null" {
+				ds := config.DisplayServer() // eg "wayland"
+				err := shell.CopyImage(fp, ds)
+				utils.HandleError(err)
+			} else {
+				err := clipboard.WriteAll(fullValue)
+				utils.HandleError(err)
+			}
+
+			if len(os.Args) > 2 {
+				if utils.IsInt(os.Args[2]) {
+					shell.KillProcess(os.Args[2])
+				}
+			} else if len(os.Args) > 1 {
+				if os.Args[1] == "keep" {
+					cmds = append(
+						cmds,
+						m.list.NewStatusMessage(statusMessageStyle("Copied to clipboard: "+title)),
+					)
+				}
+			} else {
+				return m, tea.Quit
+			}
+
+		case key.Matches(msg, m.keys.remove):
+			index := m.list.Index()
+			m.list.RemoveItem(index)
+			if len(m.list.Items()) == 0 {
+				m.keys.remove.SetEnabled(false)
+				m.list.SetShowStatusBar(false)
+			}
+			go func() { // stop cached clipboard item repopulating
+				currentContent, _ := clipboard.ReadAll()
+				if currentContent == fullValue {
+					clipboard.WriteAll("")
+				}
+				err := config.DeleteJsonItem(desc)
+				utils.HandleError(err)
+			}()
+			cmds = append(
+				cmds,
+				m.list.NewStatusMessage(statusMessageStyle("Deleted: "+title)),
+			)
+
+		case key.Matches(msg, m.keys.togglePin):
+			if len(m.list.Items()) == 0 {
+				m.keys.togglePin.SetEnabled(false)
+			}
+			// update pinned status in history file
+			isPinned, err := config.TogglePinClipboardItem(desc)
+			utils.HandleError(err)
 			m.togglePinUpdate()
-		case "shift+down", "J":
+
+			if isPinned {
+				cmds = append(
+					cmds,
+					m.list.NewStatusMessage(statusMessageStyle("UnPinned: "+title)),
+				)
+			} else {
+				cmds = append(
+					cmds,
+					m.list.NewStatusMessage(statusMessageStyle("Pinned: "+title)),
+				)
+			}
+		case key.Matches(msg, m.keys.togglePinned):
+			if len(m.list.Items()) == 0 {
+				m.keys.togglePinned.SetEnabled(false)
+			}
+			m.togglePinned = !m.togglePinned
+			if m.togglePinned {
+				m.list.Title = "Pinned " + clipboardTitle
+			} else {
+				m.list.Title = clipboardTitle
+			}
+			clipboardItems := config.GetHistory()
+			filteredItems := filterItems(clipboardItems, m.togglePinned, m.theme)
+
+			if len(filteredItems) == 0 {
+				m.list.Title = clipboardTitle
+				cmds = append(
+					cmds,
+					m.list.NewStatusMessage(statusMessageStyle("No pinned items")),
+				)
+			} else {
+				for i := len(m.list.Items()) - 1; i >= 0; i-- { // clear all items
+					m.list.RemoveItem(i)
+				}
+				for _, item := range filteredItems { // adds all required items
+					m.list.InsertItem(len(m.list.Items()), item)
+				}
+			}
+		case key.Matches(msg, m.keys.selectDown):
 			m.toggleSelected()
 			m.list.CursorDown()
-		case "shift+up", "K":
+
+		case key.Matches(msg, m.keys.selectUp):
 			m.toggleSelected()
 			m.list.CursorUp()
-		case "S":
+
+		case key.Matches(msg, m.keys.selectSingle):
 			m.toggleSelected()
-		case "?":
+
+		case key.Matches(msg, m.keys.more):
 			// swap custom help menu for default list.Model help view when expanding
 			// the menu. doing this because the custom help menu causing rendering
 			// conflits with the list view
@@ -95,41 +199,6 @@ func (m *model) toggleSelected() {
 		return
 	}
 	item.selected = !item.selected
-	item = updateSelectionStyle(item, m.theme)
+	//item = updateSelectionStyle(item, m.theme)
 	m.list.SetItem(index, item)
 }
-
-/*func (m *model) resetSelected() {
-/*
-	Need make selected items reset to dimmed when filtering
-*/
-//for i := 0; i < len(m.list.Items()); i++ {
-//	item, ok := m.list.SelectedItem().(item)
-//	if !ok {
-//		continue
-//	}
-//	item.selected = false
-//	m.list.SetItem(i, item)
-//}
-//m.list.Filter("", []string{""})
-//}
-
-/*func (m *model) addSelected() {
-
-
-
-	index := m.list.Index()
-	item, ok := m.list.SelectedItem().(item)
-	if !ok {
-		return
-	}
-	desc := item.descriptionBase
-	if item.pinned {
-		desc = desc + " " + styledPin(m.theme)
-	}
-
-	item.title = lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.SelectedTitle)).Render(item.titleBase)
-	item.description = lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.SelectedTitle)).Render(desc)
-
-	m.list.SetItem(index, item)
-}*/

--- a/app/update.go
+++ b/app/update.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -24,6 +25,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "p":
 			m.togglePinUpdate()
+		case "shift+down":
+			m.toggleSelected()
+			m.list.CursorDown()
+		case "shift+up":
+			m.toggleSelected()
+			m.list.CursorUp()
+
 		case "?":
 			// swap custom help menu for default list.Model help view when expanding
 			// the menu. doing this because the custom help menu causing rendering
@@ -66,4 +74,22 @@ func (m *model) updatePaginator() {
 		pagStyle = lipgloss.NewStyle().MarginBottom(0).MarginLeft(2)
 	}
 	m.list.Styles.PaginationStyle = pagStyle
+}
+
+func (m *model) toggleSelected() {
+	index := m.list.Index()
+	item, ok := m.list.SelectedItem().(item)
+
+	if !ok {
+		return
+	}
+	selectedChar := "➤➤➤ "
+	item.selected = !item.selected
+	if !item.selected {
+		item.title = strings.Replace(item.title, selectedChar, "", 1)
+	} else if string(item.title[0]) != selectedChar {
+		item.title = selectedChar + item.title
+	}
+	m.list.SetItem(index, item)
+
 }

--- a/app/view.go
+++ b/app/view.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -10,13 +9,14 @@ func (m model) View() string {
 	helpView := lipgloss.NewStyle().PaddingLeft(2).Render(m.help.View(m.keys))
 	render := lipgloss.NewStyle().PaddingLeft(1).Render
 
-	if m.list.FilterState() == list.Filtering {
+	if m.list.SettingFilter() {
 		return render(listView + "\n" + lipgloss.NewStyle().PaddingLeft(2).Render(
-			m.list.Help.ShortHelpView(m.filterKeys.FilterHelp())))
+			m.list.Help.ShortHelpView(m.filterKeys.FilterHelp())),
+		)
 	}
 
 	if m.list.ShowHelp() {
-		return render(listView) // default full view used as replacement
+		return render(listView)
 	}
 	return render(listView + "\n" + helpView)
 }

--- a/app/view.go
+++ b/app/view.go
@@ -14,6 +14,7 @@ func (m model) View() string {
 		return render(listView + "\n" + lipgloss.NewStyle().PaddingLeft(2).Render(
 			m.list.Help.ShortHelpView(m.filterKeys.FilterHelp())))
 	}
+
 	if m.list.ShowHelp() {
 		return render(listView) // default full view used as replacement
 	}

--- a/config/history.go
+++ b/config/history.go
@@ -140,10 +140,27 @@ func DeleteJsonItem(item string) error {
 		ClipboardHistory: updatedClipboardHistory,
 	}
 	err := WriteUpdate(updatedData)
-	if err != nil {
-		return nil
+	return err
+}
+
+func DeleteItems(timeStamps []string) error {
+	data := fileContents()
+	updatedData := []ClipboardItem{}
+
+	toDelete := make(map[string]bool)
+	for _, ts := range timeStamps {
+		toDelete[ts] = true
 	}
-	return nil
+	for _, item := range data.ClipboardHistory {
+		if !toDelete[item.Recorded] {
+			updatedData = append(updatedData, item)
+		}
+	}
+	updatedFile := ClipboardHistory{
+		ClipboardHistory: updatedData,
+	}
+	err := WriteUpdate(updatedFile)
+	return err
 }
 
 func createDir(dirPath string) error {

--- a/config/history.go
+++ b/config/history.go
@@ -139,8 +139,8 @@ func DeleteJsonItem(item string) error {
 	updatedData := ClipboardHistory{
 		ClipboardHistory: updatedClipboardHistory,
 	}
-	err := WriteUpdate(updatedData)
-	return err
+	return WriteUpdate(updatedData)
+
 }
 
 func DeleteItems(timeStamps []string) error {
@@ -159,8 +159,8 @@ func DeleteItems(timeStamps []string) error {
 	updatedFile := ClipboardHistory{
 		ClipboardHistory: updatedData,
 	}
-	err := WriteUpdate(updatedFile)
-	return err
+	return WriteUpdate(updatedFile)
+
 }
 
 func createDir(dirPath string) error {
@@ -196,11 +196,8 @@ func ClearHistory(clearType string) error {
 			ClipboardHistory: pinnedItems(),
 		}
 	}
-	err := WriteUpdate(data)
-	if err != nil {
-		return err
-	}
-	return nil
+	return WriteUpdate(data)
+
 }
 
 func pinnedItems() []ClipboardItem {
@@ -257,10 +254,7 @@ func AddClipboardItem(text, fp string) error {
 		}
 	}
 
-	if err := WriteUpdate(data); err != nil {
-		return err
-	}
-	return nil
+	return WriteUpdate(data)
 }
 
 // This pins and unpins an item in the clipboard


### PR DESCRIPTION
ref #42 

Functionality added for:

- selecting multiple items from the standard view
- direction keys + `ctrl` and `s` to toggle single items    
- copying all selected
- deleting all selected
- filter match yank _(key binding available when filtering to yank all values that match the filter value)_ 


Other:

- removed default item delegate, replacing with custom item delegate
- improved help views
- updated styling logic to meet new delegate system    
- improved handling of json when deleting items
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 