### PR TITLE
Implement automatic deletion of items after a specified time upon opening the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ The configuration capabilities of `clipse` will change as `clipse` evolves and g
   - The debug log file
   - The clipboard UI theme file
 - Setting a custom max history limit
+- Automatically deleting non-pinned entries older than specified
 - Custom themes
 - If duplicates are allowed
 - Setting custom key bindings

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	AllowDuplicates bool              `json:"allowDuplicates"`
 	HistoryFilePath string            `json:"historyFile"`
 	MaxHistory      int               `json:"maxHistory"`
+	DeleteAfter     int               `json:"deleteAfter"`
 	LogFilePath     string            `json:"logFile"`
 	ThemeFilePath   string            `json:"themeFile"`
 	TempDirPath     string            `json:"tempDir"`

--- a/config/constants.go
+++ b/config/constants.go
@@ -6,6 +6,7 @@ const (
 	defaultAllowDuplicates = false
 	defaultHistoryFile     = "clipboard_history.json"
 	defaultMaxHist         = 100
+	defaultDeleteAfter     = 0
 	defaultLogFile         = "clipse.log"
 	defaultTempDir         = "tmp_files"
 	defaultThemeFile       = "custom_theme.json"
@@ -43,6 +44,7 @@ func defaultConfig() Config {
 	return Config{
 		HistoryFilePath: defaultHistoryFile,
 		MaxHistory:      defaultMaxHist,
+		DeleteAfter:     defaultDeleteAfter,
 		AllowDuplicates: defaultAllowDuplicates,
 		TempDirPath:     defaultTempDir,
 		LogFilePath:     defaultLogFile,

--- a/config/history.go
+++ b/config/history.go
@@ -65,17 +65,15 @@ func GetHistory() []ClipboardItem {
 
 	utils.HandleError(json.NewDecoder(file).Decode(&data))
 
-	dateLayout := "2006-01-02 15:04:05.999999999"
-
 	if ClipseConfig.DeleteAfter > 0 {
 		for i, item := range data.ClipboardHistory {
-			recorded, err := time.Parse(dateLayout, item.Recorded)
+			recorded, err := time.Parse(utils.DateLayout, item.Recorded)
 			if err != nil {
 				utils.LogERROR(fmt.Sprintf("Could not parse the date string: %s", item.Recorded))
 				continue
 			}
 
-			currentTime, err := time.Parse(dateLayout, utils.GetTime())
+			currentTime, err := time.Parse(utils.DateLayout, utils.GetTime())
 
 			if err != nil {
 				utils.LogERROR("Could not convert the current time string to a time object")

--- a/config/history.go
+++ b/config/history.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/savedra1/clipse/shell"
 	"github.com/savedra1/clipse/utils"
-	"slices"
 )
 
 /* File contains logic for parsing the clipboard history.

--- a/config/history.go
+++ b/config/history.go
@@ -86,7 +86,7 @@ func GetHistory() []ClipboardItem {
 
 			deletionTime := recorded.Add(time.Duration(ClipseConfig.DeleteAfter * int(time.Second)))
 			if deletionTime.Before(currentTime) {
-				RemoveClipboardItem(i)
+				utils.HandleError(RemoveClipboardItem(i))
 				continue
 			}
 		}
@@ -241,15 +241,15 @@ func AddClipboardItem(text, fp string) error {
 
 func RemoveClipboardItem(index int) error {
 	data := fileContents()
-	new_data := ClipboardHistory{}
+	newData := ClipboardHistory{}
 
 	for i, item := range data.ClipboardHistory {
 		if i != index {
-			new_data.ClipboardHistory = append(new_data.ClipboardHistory, item)
+			newData.ClipboardHistory = append(newData.ClipboardHistory, item)
 		}
 	}
 
-	return WriteUpdate(new_data)
+	return WriteUpdate(newData)
 }
 
 func duplicateItems(currentHistory []ClipboardItem, newItem ClipboardItem) ([]string, bool) {

--- a/config/history.go
+++ b/config/history.go
@@ -67,6 +67,10 @@ func GetHistory() []ClipboardItem {
 
 	if ClipseConfig.DeleteAfter > 0 {
 		for i, item := range data.ClipboardHistory {
+			if item.Pinned {
+				continue
+			}
+
 			recorded, err := time.Parse(utils.DateLayout, item.Recorded)
 			if err != nil {
 				utils.LogERROR(fmt.Sprintf("Could not parse the date string: %s", item.Recorded))

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -3,4 +3,5 @@ package utils
 const (
 	maxChar      = 65
 	imgNameRegEx = `^(\d{1,10})-\d{1,10}\.png$`
+	DateLayout   = "2006-01-02 15:04:05.999999999"
 )

--- a/utils/string.go
+++ b/utils/string.go
@@ -40,7 +40,7 @@ func GetStdin() string {
 }
 
 func GetTime() string {
-	return time.Now().Format(("2006-01-02 15:04:05.000000000"))
+	return time.Now().Format(DateLayout)
 }
 
 func GetTimeStamp() string {


### PR DESCRIPTION
Implements the basics of the idea expressed in #139

Every time the history is fetched, it is first searched for any entries older than the number of seconds specified in the config file
```json
"deleteAfter": 10
```
0 means no timeout.
The entries found to be older than the number of seconds specified get removed.