### PR TITLE
Add a new command argument to pause clipbaord monitoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Does not require any additional dependency, but may require you to use a termina
 - [Customizable maximum history limit](#configuration)
 - Filter items using a fuzzy find
 - Image and text previews
-- Mult-selection of items for copy and delete operations
+- Multi-selection of items for copy and delete operations
 - Bulk copy all active filter matches
 - Pin items/pinned items view
 - Vim-like keybindings for navigation available
-- [Run on any Unix machine](#Versatility) with single binary for the clipbboard monitor and TUI
+- [Run on any Unix machine](#Versatility) with single binary for the clipboard monitor and TUI
 - Optional duplicates
 - Ability to set custom key bindings
 
@@ -486,7 +486,7 @@ I would love to receive contributions to this project and welcome PRs from every
   - [x] ~~Menu theme~~
   - [x] ~~Filter theme~~
   - [x] ~~Clear TUI view on select and close _(mirror close effect from `q` or `esc`)_~~
-- [ ] Private mode _(eg `clipse --pause 1` )_
+- [x] ~~Private mode _(eg `clipse --pause 1` )_~~
 
 ## FAQ
 

--- a/app/update.go
+++ b/app/update.go
@@ -400,10 +400,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.setPreviewKeys(true)
 
 				return m, tea.Batch(cmds...)
-			} else {
-				if i.filePath != "null" && config.ClipseConfig.ImageDisplay.Type != "basic" {
-					m.preview.Height = m.originalHeight
-				}
+			}
+			if i.filePath != "null" && config.ClipseConfig.ImageDisplay.Type != "basic" {
+				m.preview.Height = m.originalHeight
 			}
 			m.setPreviewKeys(false)
 		}

--- a/config/constants.go
+++ b/config/constants.go
@@ -10,7 +10,8 @@ const (
 	defaultLogFile         = "clipse.log"
 	defaultTempDir         = "tmp_files"
 	defaultThemeFile       = "custom_theme.json"
-	listenCmd              = "--listen-shell"
+	listenShellCmd         = "--listen-shell"
+	listenCmd              = "-listen"
 	maxChar                = 65
 )
 

--- a/main.go
+++ b/main.go
@@ -17,24 +17,24 @@ import (
 )
 
 var (
-	version     = "v1.1.0"
-	help        = flag.Bool("help", false, "Show help message.")
-	v           = flag.Bool("v", false, "Show app version.")
-	add         = flag.Bool("a", false, "Add the following arg to the clipboard history.")
-	copyInput   = flag.Bool("c", false, "Copy the input to your systems clipboard.")
-	paste       = flag.Bool("p", false, "Prints the current clipboard content.")
-	listen      = flag.Bool("listen", false, "Start background process for monitoring clipboard activity on wayland/x11/macOS.")
-	listenShell = flag.Bool("listen-shell", false, "Starts a clipboard monitor process in the current shell.")
-	kill        = flag.Bool("kill", false, "Kill any existing background processes.")
-	clear       = flag.Bool("clear", false, "Remove all contents from the clipboard history except for pinned items.")
-	clearAll    = flag.Bool("clear-all", false, "Remove all contents the clipboard history including pinned items.")
-	clearImages = flag.Bool("clear-images", false, "Removes all images from the clipboard history including pinned images.")
-	clearText   = flag.Bool("clear-text", false, "Removes all text from the clipboard history including pinned text entries.")
-	forceClose  = flag.Bool("fc", false, "Forces the terminal session to quick by taking the $PPID var as an arg. EG `clipse -fc $PPID`")
-	wlStore     = flag.Bool("wl-store", false, "Store data from the stdin directly using the wl-clipboard API.")
-	realTime    = flag.Bool("enable-real-time", false, "Enable real time updates to the TUI")
-	outputAll   = flag.String("output-all", "", "Print clipboard text content to stdout, each entry separated by a newline, possible values: (raw, unescaped)")
-	pause       = flag.String("pause", "0", "Pause clipboard monitoring for a specified duration. Example: `clipse -pause 5m` pauses for 5 minutes.")
+	version       = "v1.1.0"
+	help          = flag.Bool("help", false, "Show help message.")
+	v             = flag.Bool("v", false, "Show app version.")
+	add           = flag.Bool("a", false, "Add the following arg to the clipboard history.")
+	copyInput     = flag.Bool("c", false, "Copy the input to your systems clipboard.")
+	paste         = flag.Bool("p", false, "Prints the current clipboard content.")
+	listen        = flag.Bool("listen", false, "Start background process for monitoring clipboard activity on wayland/x11/macOS.")
+	listenShell   = flag.Bool("listen-shell", false, "Starts a clipboard monitor process in the current shell.")
+	kill          = flag.Bool("kill", false, "Kill any existing background processes.")
+	clearUnpinned = flag.Bool("clear", false, "Remove all contents from the clipboard history except for pinned items.")
+	clearAll      = flag.Bool("clear-all", false, "Remove all contents the clipboard history including pinned items.")
+	clearImages   = flag.Bool("clear-images", false, "Removes all images from the clipboard history including pinned images.")
+	clearText     = flag.Bool("clear-text", false, "Removes all text from the clipboard history including pinned text entries.")
+	forceClose    = flag.Bool("fc", false, "Forces the terminal session to quick by taking the $PPID var as an arg. EG `clipse -fc $PPID`")
+	wlStore       = flag.Bool("wl-store", false, "Store data from the stdin directly using the wl-clipboard API.")
+	realTime      = flag.Bool("enable-real-time", false, "Enable real time updates to the TUI")
+	outputAll     = flag.String("output-all", "", "Print clipboard text content to stdout, each entry separated by a newline, possible values: (raw, unescaped)")
+	pause         = flag.String("pause", "0", "Pause clipboard monitoring for a specified duration. Example: `clipse -pause 5m` pauses for 5 minutes.")
 )
 
 func main() {
@@ -80,7 +80,7 @@ func main() {
 	case *kill:
 		handleKill()
 
-	case *clear, *clearAll, *clearImages, *clearText:
+	case *clearUnpinned, *clearAll, *clearImages, *clearText:
 		handleClear()
 
 	case *forceClose:

--- a/main.go
+++ b/main.go
@@ -161,6 +161,9 @@ func handleListen(displayServer string) {
 		fmt.Printf("ERROR: failed to kill existing listener process: %s", err)
 		utils.LogERROR(fmt.Sprintf("failed to kill existing listener process: %s", err))
 	}
+	// Clear the clipboard first to avoid capturing clipboard data before the user
+	// expresses their intent to start monitoring.
+	clipboard.WriteAll("")
 	shell.RunNohupListener(displayServer)
 }
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ var (
 	wlStore     = flag.Bool("wl-store", false, "Store data from the stdin directly using the wl-clipboard API.")
 	realTime    = flag.Bool("enable-real-time", false, "Enable real time updates to the TUI")
 	outputAll   = flag.String("output-all", "", "Print clipboard text content to stdout, each entry separated by a newline, possible values: (raw, unescaped)")
-	pause		= flag.String("pause", "0", "Pause clipboard monitoring for a specified duration. Example: `clipse -pause 5m` pauses for 5 minutes.")
+	pause       = flag.String("pause", "0", "Pause clipboard monitoring for a specified duration. Example: `clipse -pause 5m` pauses for 5 minutes.")
 )
 
 func main() {
@@ -94,16 +94,16 @@ func main() {
 
 	case *outputAll != "":
 		handleOutputAll(*outputAll)
-	
+
 	case *pause != "":
-		handlePause(*pause, displayServer)
+		handlePause(*pause)
 
 	default:
 		fmt.Printf("Command not recognized. See %s --help for usage instructions.", os.Args[0])
 	}
 }
 
-func handlePause(s string, displayServer string) {
+func handlePause(s string) {
 	ok, err := shell.IsListenerRunning()
 	if err != nil {
 		fmt.Printf("Error checking for active clipboard monitoring process: %s\n", err)
@@ -116,13 +116,13 @@ func handlePause(s string, displayServer string) {
 	usageMsg := fmt.Sprintf("Usage: %s -pause <duration>\nWhere duration is in seconds, minutes, or hours. Example: %s -pause 5m pauses for 5 minutes.", os.Args[0], os.Args[0])
 	if s == "0" {
 		fmt.Println("Invalid duration. Use a positive duration to pause clipboard monitoring.")
-		fmt.Printf(usageMsg)
+		fmt.Println(usageMsg)
 		return
 	}
 	duration, err := time.ParseDuration(s)
 	if err != nil {
 		fmt.Printf("Invalid duration format: %s\n", err)
-		fmt.Printf(usageMsg)
+		fmt.Println(usageMsg)
 		return
 	}
 	if err := shell.KillExisting(); err != nil {
@@ -163,7 +163,9 @@ func handleListen(displayServer string) {
 	}
 	// Clear the clipboard first to avoid capturing clipboard data before the user
 	// expresses their intent to start monitoring.
-	clipboard.WriteAll("")
+	if err := clipboard.WriteAll(""); err != nil {
+		utils.LogERROR(fmt.Sprintf("failed to reset clipboard buffer value: %s", err))
+	}
 	shell.RunNohupListener(displayServer)
 }
 

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func handlePause(s string, displayServer string) {
 		return
 	}
 	fmt.Printf("Pausing clipboard monitoring for %s...\n", duration)
-	shell.RunNohupListener(displayServer, &duration)
+	shell.RunListenerAfterDelay(&duration)
 }
 
 func launchTUI() {
@@ -161,7 +161,7 @@ func handleListen(displayServer string) {
 		fmt.Printf("ERROR: failed to kill existing listener process: %s", err)
 		utils.LogERROR(fmt.Sprintf("failed to kill existing listener process: %s", err))
 	}
-	shell.RunNohupListener(displayServer, nil)
+	shell.RunNohupListener(displayServer)
 }
 
 func handleListenShell(displayServer string, imgEnabled bool) {

--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -125,7 +125,8 @@ func RunNohupListener(displayServer string) {
 }
 
 func nohupCmdWL(dataType string) *exec.Cmd {
-	return exec.Command(
+	cmd := exec.Command(
+		"nohup",
 		wlPasteHandler,
 		wlTypeSpec,
 		dataType,
@@ -136,6 +137,7 @@ func nohupCmdWL(dataType string) *exec.Cmd {
 		"2>&1",
 		"&",
 	)
+	return cmd
 }
 
 func KillProcess(ppid string) {

--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -7,11 +7,29 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	ps "github.com/mitchellh/go-ps"
 
 	"github.com/savedra1/clipse/utils"
 )
+
+func IsListenerRunning() (bool, error) {
+	/*
+		Check if clipse is running by checking if the process is in the process list.
+	*/
+	psList, err := ps.Processes()
+	if err != nil {
+		return false, fmt.Errorf("failed to get processes: %w", err)
+	}
+
+	for _, p := range psList {
+		if strings.Contains(os.Args[0], p.Executable()) || strings.Contains(wlPasteHandler, p.Executable()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 func KillExisting() error {
 	/*
@@ -74,23 +92,52 @@ func KillAll(bin string) {
 	}
 }
 
-func RunNohupListener(displayServer string) {
+func RunNohupListener(displayServer string, delay *time.Duration) {
 	switch displayServer {
 	case "wayland":
 		// run optimized wl-clipboard listener
-		utils.HandleError(nohupCmdWL("image/png").Start())
-		utils.HandleError(nohupCmdWL("text").Start())
+		utils.HandleError(nohupCmdWL("image/png", delay).Start())
+		utils.HandleError(nohupCmdWL("text", delay).Start())
 
 	default:
 		// run default poll listener
-		cmd := exec.Command("nohup", os.Args[0], listenCmd, ">/dev/null", "2>&1", "&")
+		var cmd *exec.Cmd
+		if delay != nil {
+			cmd = exec.Command(
+				"sh",
+				"-c",
+				fmt.Sprintf(
+					"sleep %d && nohup %s %s >/dev/null 2>&1 &",
+					int(delay.Seconds()),
+					os.Args[0],
+					listenCmd,
+				),
+			)
+		} else {
+			cmd = exec.Command("nohup", os.Args[0], listenCmd, ">/dev/null", "2>&1", "&")
+		}
 		utils.HandleError(cmd.Start())
 	}
 }
 
-func nohupCmdWL(dataType string) *exec.Cmd {
-	cmd := exec.Command(
-		"nohup",
+func nohupCmdWL(dataType string, delay *time.Duration) *exec.Cmd {
+	if delay != nil {
+		return exec.Command(
+			"sh",
+			"-c",
+			fmt.Sprintf(
+				"sleep %d && nohup %s %s %s %s %s %s >/dev/null 2>&1 &",
+				int(delay.Seconds()),
+				wlPasteHandler,
+				wlTypeSpec,
+				dataType,
+				wlPasteWatcher,
+				os.Args[0],
+				wlStoreCmd,
+			),
+		)
+	}
+	return exec.Command(
 		wlPasteHandler,
 		wlTypeSpec,
 		dataType,
@@ -101,7 +148,6 @@ func nohupCmdWL(dataType string) *exec.Cmd {
 		"2>&1",
 		"&",
 	)
-	return cmd
 }
 
 func KillProcess(ppid string) {

--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -74,7 +74,7 @@ func KillExistingFG() {
 
 	psList := strings.Split(string(output), "\n")
 	for _, ps := range psList {
-		if strings.Contains(ps, currentPS) || strings.Contains(ps, listenCmd) || strings.Contains(ps, wlStoreCmd) {
+		if strings.Contains(ps, currentPS) || strings.Contains(ps, listenShellCmd) || strings.Contains(ps, wlStoreCmd) {
 			continue
 		}
 		if ps != "" {
@@ -119,7 +119,7 @@ func RunNohupListener(displayServer string) {
 		utils.HandleError(nohupCmdWL("text").Start())
 	default:
 		// run default poll listener
-		cmd := exec.Command("nohup", os.Args[0], listenCmd, ">/dev/null", "2>&1", "&")
+		cmd := exec.Command("nohup", os.Args[0], listenShellCmd, ">/dev/null", "2>&1", "&")
 		utils.HandleError(cmd.Start())
 	}
 }

--- a/shell/constants.go
+++ b/shell/constants.go
@@ -3,7 +3,7 @@ package shell
 const (
 	listenCmd      = "-listen"
 	listenShellCmd = "--listen-shell" // internal
-	pgrepCmd       = "pgrep -a clipse"
+	pgrepCmd       = "ps -eo pid,command | grep '[c]lipse'"
 	wlVersionCmd   = "wl-copy -v"
 	wlPasteHandler = "wl-paste"
 	wlPasteWatcher = "--watch"

--- a/shell/constants.go
+++ b/shell/constants.go
@@ -1,8 +1,9 @@
 package shell
 
 const (
-	listenCmd      = "--listen-shell" // internal
-	pgrepCmd       = "ps -eo pid,command | grep '[c]lipse'"
+	listenCmd      = "-listen"
+	listenShellCmd = "--listen-shell" // internal
+	pgrepCmd       = "pgrep -a clipse"
 	wlVersionCmd   = "wl-copy -v"
 	wlPasteHandler = "wl-paste"
 	wlPasteWatcher = "--watch"


### PR DESCRIPTION
## Private Mode

Introducing a new command argument to pause clipboard monitoring for a given period of time.

I followed the approach suggested in the corresponding [issue](https://github.com/savedra1/clipse/issues/54). Let me know what you think.

### Caveats

I haven't touched the TUI to surface pausing details like status and remaining time.