### PR TITLE
issue/203: (fix) TUI launch killing background listener on MacOS

### DIFF
--- a/shell/constants.go
+++ b/shell/constants.go
@@ -2,7 +2,7 @@ package shell
 
 const (
 	listenCmd      = "--listen-shell" // internal
-	pgrepCmd       = "pgrep -a clipse"
+	pgrepCmd       = "ps -eo pid,command | grep '[c]lipse'"
 	wlVersionCmd   = "wl-copy -v"
 	wlPasteHandler = "wl-paste"
 	wlPasteWatcher = "--watch"


### PR DESCRIPTION
`pgrep` does not output full command on MacOS, causing program to treat all results as foreground process.