### PR TITLE
Don't save wayland clipboard if it contains sensitive data

### DIFF
--- a/handlers/wayland.go
+++ b/handlers/wayland.go
@@ -18,6 +18,11 @@ import (
 )
 
 func StoreWLData() {
+	/* See `man wl-clipboard` for more information */
+	if os.Getenv("CLIPBOARD_STATE") == "sensitive" {
+		return
+	}
+
 	input, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		utils.LogERROR(fmt.Sprintf("failed to read stdin: %s", err))


### PR DESCRIPTION
This should fix #222 in Wayland when using the latest unreleased wl-clipboard.
On Arch you can use wl-clipboard-git from UAR.