### PR TITLE
Fix: Improve KillProcess

### DIFF
--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -74,11 +74,16 @@ func KillExistingFG() {
 
 	psList := strings.Split(string(output), "\n")
 	for _, ps := range psList {
-		if strings.Contains(ps, currentPS) || strings.Contains(ps, listenShellCmd) || strings.Contains(ps, wlStoreCmd) {
+		fields := strings.Fields(ps)
+		if len(fields) == 0 {
+			continue
+		}
+		pid := fields[0]
+		if pid == currentPS || strings.Contains(ps, listenShellCmd) || strings.Contains(ps, wlStoreCmd) {
 			continue
 		}
 		if ps != "" {
-			KillProcess(strings.Split(ps, " ")[0])
+			KillProcess(pid)
 		}
 	}
 }

--- a/shell/constants.go
+++ b/shell/constants.go
@@ -3,7 +3,7 @@ package shell
 const (
 	listenCmd      = "-listen"
 	listenShellCmd = "--listen-shell" // internal
-	pgrepCmd       = "ps -eo pid,command | grep '[c]lipse'"
+	pgrepCmd       = "ps -C clipse -o pid,command --no-header"
 	wlVersionCmd   = "wl-copy -v"
 	wlPasteHandler = "wl-paste"
 	wlPasteWatcher = "--watch"


### PR DESCRIPTION
1. The original method will kill process with "clipse" keyword incorrectly. For example `nvim ~/.config/clipse/cofig.json` could be killed with the original method.
2. the `ps` output line could have whitespace at the beginning.