### PR TITLE
Improve readme for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ bindsym $mod+V exec <terminal name> --class clipse -e clipse                    
 
 ### macOS
 
+When `clipse` is started for the first time, configuration and other files will be created in `~/Library/Application\ Support/clipse`.
+
 #### Run the clipse listener on startup
 
 One method is to create a launch agent for `clipse`.

--- a/README.md
+++ b/README.md
@@ -316,7 +316,38 @@ bindsym $mod+V exec <terminal name> --class clipse -e clipse                    
 
 ### macOS
 
-The native terminal on macOS will not close once the `clipse` program completes, even when using the `-fc` argument. You will therefore need to use a different terminal environment like [Alacritty](https://alacritty.org/) or [Ghostty](https://ghostty.org/) to achieve the "close on selection" effect. The bindings used to open the TUI, for example the command `open -na Alacritty --args -e /path/to/clipse`, will then need to be defined in your settings/window manager.
+#### Run the clipse listener on startup
+
+One method is to create a launch agent for `clipse`.
+
+Create the file `~/Library/LaunchAgents/clipse.plist` with the following content:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"\>
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.savedra1.clipse</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/clipse</string>
+        <string>--listen-shell</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+```
+
+Then in a terminal, activate the agent with: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/clipse.plist`. Right away and after your next login, you can check that `clipse` is running by executing `ps -e | grep '[c]lipse'`.
+
+#### Open clipse's TUI (with a system-wide shortcut)
+
+The native terminal on macOS will not close once the `clipse` program completes, even when using the `-fc` argument. You will therefore need to use a different terminal environment like [Alacritty](https://alacritty.org/) or [Ghostty](https://ghostty.org/) to achieve the "close on selection" effect. 
+
+One way to open the TUI on macOS is thus by running the command `open -na Alacritty --args -e /path/to/clipse`. 
+
+To bind the command to a system-wide shortcut, you can use specialized tools such as [Raycast](https://www.raycast.com/) or [BetterTouchTool](https://folivora.ai/). You can also use a native keyboard shortcut to trigger an Automator App or Service running that command (but opening the TUI may be slower this way).
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If moving to a new release of `clipse` please review the [changelog](https://git
 
 __[atotto/clipboard](https://github.com/atotto/clipboard)__
 
-This requires a system clipboard. I would recommend using `wl-clipboard` (Wayland) or `xclip` (X11/macOs) to get the best results. You can also use `xsel` and `termux-clipboard`, but these will not allow you to copy images.
+This requires a system clipboard. I would recommend using `wl-clipboard` (Wayland) or `xclip` (X11/macOS) to get the best results. You can also use `xsel` and `termux-clipboard`, but these will not allow you to copy images.
 
 __[BubbleTea](https://pkg.go.dev/github.com/charmbracelet/bubbletea)__
 
@@ -314,9 +314,9 @@ bindsym $mod+V exec <terminal name> --class clipse -e clipse                    
 
 [Sway reference](https://wiki.archlinux.org/title/Sway#Floating_windows)
 
-### MacOs
+### macOS
 
-The native terminal on MacOs will not close once the `clipse` program completes, even when using the `-fc` argument. You will therefore need to use a different terminal environment like [Alacritty](https://alacritty.org/) to achieve the "close on selection" effect. The bindings used to open the TUI will then need to be defined in your settings/window manager.
+The native terminal on macOS will not close once the `clipse` program completes, even when using the `-fc` argument. You will therefore need to use a different terminal environment like [Alacritty](https://alacritty.org/) or [Ghostty](https://ghostty.org/) to achieve the "close on selection" effect. The bindings used to open the TUI, for example the command `open -na Alacritty --args -e /path/to/clipse`, will then need to be defined in your settings/window manager.
 
 ### Other
 
@@ -497,7 +497,7 @@ See issue #148. This is caused by the fuzzy find algo _(within the BubbleTea TUI
 
 __My terminal window does not close on selection, even when using `clipse -fc $PPID`__
 
-Some terminal environments reference system variables differently. For example, the fish terminal will need to use `$fish_pid` instead. To debug this error you can run `echo $PPID` to see what gets returned. To get the "close on selection" effect for macOs, you will need to install a different terminal environment like `Alacritty`._
+Some terminal environments reference system variables differently. For example, the fish terminal will need to use `$fish_pid` instead. To debug this error you can run `echo $PPID` to see what gets returned. For macOS, see [macOS](#macOS).
 <br>
 
 __Is there risk of multiple parallel processes running?__
@@ -531,6 +531,6 @@ Depending on the clipboard utility you are using (`wl-clipboard`/`xclip` etc) th
 <br>
 If using `wayland`, copying images from your browser should now work from most sites if using `v1.0.4` or later. This may copy the binary data as well as the metadata sting as a separate entry. Some sites/browsers may add the browser image data to the stdin in a way that `wl-clipboard` does not recognize.
 <br>
-If using `x11`, `MacOs` or other and copying browser images does not work, feel free to raise and issue (or a PR) detailing which sites/browser engines this does not work with for you.
+If using `x11`, `macOS` or other and copying browser images does not work, feel free to raise and issue (or a PR) detailing which sites/browser engines this does not work with for you.
   
 <br>


### PR DESCRIPTION
This PR just improves README a bit for macOS:

- Add instructions on how to auto-start the clipse listener
- Give an example of how to open the TUI
- Add pointers on how to configure system-wide keyboard shortcuts
- Add a note on config files location
- Remove some duplicate explanation