### PR TITLE
feat: add 'back' and 'choose' keybind for preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ The configuration capabilities of `clipse` will change as `clipse` evolves and g
         "nextPage": "right",
         "prevPage": "left",
         "preview": "t",
+        "previewBack": "esc",
         "quit": "q",
         "remove": "x",
         "selectDown": "ctrl+down",

--- a/app/keys.go
+++ b/app/keys.go
@@ -28,6 +28,7 @@ type keyMap struct {
 	prevPage      key.Binding
 	home          key.Binding
 	end           key.Binding
+	previewBack   key.Binding
 }
 
 func newKeyMap(config map[string]string) *keyMap {
@@ -106,6 +107,9 @@ func newKeyMap(config map[string]string) *keyMap {
 		),
 		end: key.NewBinding(
 			key.WithKeys(config["end"]),
+		),
+		previewBack: key.NewBinding(
+			key.WithKeys(config["previewBack"]),
 		),
 	}
 }
@@ -193,6 +197,7 @@ type previewKeymap struct {
 	back     key.Binding
 	pageDown key.Binding
 	pageUp   key.Binding
+	choose   key.Binding
 }
 
 func newPreviewKeyMap() *previewKeymap {
@@ -220,16 +225,20 @@ func newPreviewKeyMap() *previewKeymap {
 			key.WithKeys("PgUp"),
 			key.WithHelp("PgUp", "page up"),
 		),
+		choose: key.NewBinding(
+			key.WithKeys(config["choose"]),
+			key.WithHelp("↵", "copy"),
+		),
 		back: key.NewBinding(
-			key.WithKeys(config["preview"], config["quit"]),
-			key.WithHelp(previewChar, "back"),
+			key.WithKeys(config["preview"], config["previewBack"]),
+			key.WithHelp(previewChar+" / "+config["previewBack"], "back"),
 		),
 	}
 }
 
 func (pk previewKeymap) PreviewHelp() []key.Binding {
 	return []key.Binding{
-		pk.up, pk.down, pk.pageDown, pk.pageUp, pk.back,
+		pk.up, pk.down, pk.pageDown, pk.pageUp, pk.back, pk.choose,
 	}
 }
 

--- a/app/update.go
+++ b/app/update.go
@@ -405,6 +405,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.preview.Height = m.originalHeight
 			}
 			m.setPreviewKeys(false)
+
+		case key.Matches(msg, m.keys.previewBack):
+			if m.showPreview {
+				m.showPreview = !m.showPreview
+				m.setPreviewKeys(false)
+			}
 		}
 	}
 
@@ -575,7 +581,6 @@ func (m *Model) setPreviewKeys(v bool) {
 	m.list.KeyMap.ShowFullHelp.SetEnabled(!v)
 
 	m.keys.remove.SetEnabled(!v)
-	m.keys.choose.SetEnabled(!v)
 	m.keys.togglePin.SetEnabled(!v)
 	m.keys.togglePinned.SetEnabled(!v)
 	m.keys.selectDown.SetEnabled(!v)

--- a/config/constants.go
+++ b/config/constants.go
@@ -26,6 +26,7 @@ func defaultKeyBindings() map[string]string {
 		"togglePin":     "p",
 		"togglePinned":  "tab",
 		"preview":       " ",
+		"previewBack":   "esc",
 		"selectDown":    "ctrl+down",
 		"selectUp":      "ctrl+up",
 		"selectSingle":  "s",


### PR DESCRIPTION
There isn't a GitHub issue to enable the `choose` keybind while previewing, but I thought it makes sense to add it. 

I'm not sure if `esc` should be hardcoded, so I added `previewBack` to the config

resolves #205