### PR TITLE
Exit code 1 on quit

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -32,6 +32,7 @@ type Model struct {
 	showPreview      bool                // whether the viewport preview should be displayed
 	previewKeys      *previewKeymap      // keybindings for the viewport model
 	lastUpdated      time.Time
+	ExitCode         int
 }
 
 type item struct {
@@ -88,6 +89,7 @@ func NewModel() Model {
 		preview:          NewPreview(),
 		showPreview:      false,
 		previewKeys:      newPreviewKeyMap(keyConfig),
+		ExitCode:         0,
 	}
 
 	entryItems := filterItems(clipboardItems, false, m.theme)

--- a/app/update.go
+++ b/app/update.go
@@ -429,6 +429,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 
 			default:
+				m.ExitCode = 1
 				return m, tea.Quit
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -142,8 +142,14 @@ func launchTUI() {
 	if *realTime {
 		go newModel.ListenRealTime(p)
 	}
-	_, err := p.Run()
+	finalModel, err := p.Run()
 	utils.HandleError(err)
+
+	if m, ok := finalModel.(app.Model); ok {
+		if m.ExitCode != 0 {
+			os.Exit(m.ExitCode)
+		}
+	}
 }
 
 func handleAdd() {


### PR DESCRIPTION
Added exit code 1 when user quits TUI with 'q'. This different exit code allows scripts to discriminate if a clipboard entry was selected for pasting automatically the content or do nothing in case the user just quits.

I understand if you don't want to merge this as it has the wrong semantics: the program didn't result in error as an exit code !=0 would generally mean. Also, it's inconsistent as ctrl+c or Esc would still exit with code 0.

All that said, this little change made my experience much enjoyable with clipse. Also reading some of the Issues, it seems that automatic pasting is a quite popular request.