### PR TITLE
xVersionCmd should be xclip -version not -v

### DIFF
--- a/shell/constants.go
+++ b/shell/constants.go
@@ -12,7 +12,7 @@ const (
 	wlPasteImgCmd     = "wl-paste -t image/png > %s"
 	wlStoreCmd        = "--wl-store" // internal
 	wlTypeSpec        = "--type"
-	xVersionCmd       = "xclip -v"
+	xVersionCmd       = "xclip -version"
 	xCopyImgCmd       = "xclip -selection clipboard -t image/png -i %s"
 	xPasteImgCmd      = "xclip -selection clipboard -t image/png -o > %s"
 	darwinVersionCmd  = "pngpaste -v"


### PR DESCRIPTION
I've been getting an error on different systems (X11 and macOS, if I recall correctly) that xclip is not installed, even though it is. The problem is that `xVersionCmd` checks for the program through `xclip -v`, but for me at least that returns an error (exit code 1). The correct command seems to be `xclip -version`.