### PR TITLE
Update hyprland configuration example to work with v.0.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ clipse -listen
 
   exec-once = clipse -listen # run listener on startup
 
-  windowrulev2 = float,class:(clipse) # ensure you have a floating window class set if you want this behavior
-  windowrulev2 = size 622 652,class:(clipse) # set the size of the window as necessary
+  windowrule = match:class clipse, float true # ensure you have a floating window class set if you want this behavior
+  windowrule = match:class clipse, size 622 652 # set the size of the window as necessary
 
   bind = SUPER, V, exec,  <terminal name> --class clipse -e 'clipse'
 


### PR DESCRIPTION
The new version of Hyprland (0.53) does not support `windowrulev2` syntax anymore (see https://hypr.land/news/update53/), so I updated the Hyprland configuration example to make it work with the new windowrule syntax