### PR TITLE
fix: sanitize filter targets to prevent fuzzy search panic on binary data

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -95,6 +97,7 @@ func NewModel() Model {
 	del := m.newItemDelegate()
 
 	clipboardList := list.New(entryItems, del, 0, 0)
+	clipboardList.Filter = sanitizedFilter
 	clipboardList.KeyMap = defaultOverrides(config.ClipseConfig.KeyBindings)   // override default list keys with custom values
 	clipboardList.Title = clipboardTitle                                       // set hardcoded title
 	clipboardList.SetShowHelp(false)                                           // override with custom
@@ -125,6 +128,23 @@ func NewModel() Model {
 	m.enableConfirmationKeys(false)
 
 	return m
+}
+
+func sanitizedFilter(term string, targets []string) []list.Rank {
+	sanitized := make([]string, len(targets))
+	for i, t := range targets {
+		sanitized[i] = stripNonPrintable(t)
+	}
+	return list.DefaultFilter(term, sanitized)
+}
+
+func stripNonPrintable(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return -1
+	}, s)
 }
 
 // if isPinned is true, returns only an array of pinned items, otherwise all


### PR DESCRIPTION
## Summary

- Strip non-printable characters from filter targets before passing to the fuzzy search algorithm
- The `sahilm/fuzzy` library panics with `index out of range` when it encounters non-ASCII/binary data in clipboard entries (typically from copied images)
- This preserves full fuzzy matching — search works normally on the printable text content

## Context

Fix for #148. The root cause is in `sahilm/fuzzy` which doesn't handle all byte sequences safely. Rather than patching the dependency, we sanitize inputs with `unicode.IsPrint` before they reach the fuzzy matcher.

## Test plan

- [ ] Open clipse TUI with images in clipboard history
- [ ] Press `/` to enter filter mode
- [ ] Type single characters that previously caused a crash (varies per history content — common triggers: `a`, `f`, `g`, `i`, `t`)
- [ ] Verify fuzzy search returns matching results normally
- [ ] Verify image entries don't cause crashes during filtering