### PR TITLE
issues/330: (fix) reset img preview height on quit

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -318,6 +318,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 				m.preview.GotoTop()
 				m.setPreviewKeys(false)
+				if i.filePath != "null" && config.ClipseConfig.ImageDisplay.Type != "basic" {
+					m.preview.Height = m.originalHeight
+				}
 				return m, tea.Batch(cmds...)
 
 			case m.list.IsFiltered():


### PR DESCRIPTION
Fix #330 by resetting image height when quitting from image preview.