### PR TITLE
fix: detach wl-copy from parent process on Wayland clipboard copy

### DIFF
--- a/shell/wayland.go
+++ b/shell/wayland.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/savedra1/clipse/utils"
 )
@@ -20,7 +21,8 @@ func GetWLClipBoard() (string, error) {
 
 func UpdateWLClipboard(s string) error {
 	cmd := exec.Command(wlCopyHandler, "--", s)
-	if err := cmd.Run(); err != nil {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
I was having problems using clipse where copying from the TUI would appear to work but nothing could be pasted. After debugging, the issue is that when the clipse terminal window closes after selection, it kills the wl-copy child process along with it — and on Wayland, wl-copy must
stay alive to hold the clipboard seat. When it dies, the clipboard is immediately empty.

The fix is a 3-line change: use cmd.Start() with Setsid: true instead of cmd.Run(). This puts wl-copy in its own process session so it survives the parent exiting. When a new item is copied, the old wl-copy exits naturally as it loses clipboard ownership to the new one — no process
leak.

Environment: Ubuntu 22.04, Sway. My work machine on Ubuntu 24.04 doesn't exhibit this — likely because it has a clipboard persistence daemon running that masks the bug.

I used Kiro to help locate and implement the fix.