### PR TITLE
fix: disk space checks and storage path validation #348

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "clipse dev shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      buildInputs = with pkgs; [
+        go
+        gnumake
+      ];
+
+      shellHook = ''
+        echo "clipse dev shell ready"
+        echo "  make wayland  → Wayland build"
+        echo "  make x11      → X11 build"
+      '';
+    };
+  };
+}

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -13,7 +13,7 @@ import (
 )
 
 func SaveImage(imgData []byte) error {
-	if !utils.DiskspaceAvailable(len(imgData)) {
+	if !utils.DiskspaceAvailable(len(imgData), config.ClipseConfig.TempDirPath) {
 		return fmt.Errorf("no available disk space to store image")
 	}
 
@@ -33,6 +33,9 @@ func SaveImage(imgData []byte) error {
 }
 
 func SaveText(textData string) error {
+	if !utils.DiskspaceAvailable(len(textData), config.ClipseConfig.HistoryFilePath) {
+		return fmt.Errorf("no available disk space to store text")
+	}
 	if err := config.AddClipboardItem(textData, "null"); err != nil {
 		return err
 	}

--- a/handlers/wayland.go
+++ b/handlers/wayland.go
@@ -56,6 +56,10 @@ func StoreWLData() {
 		if inputStr == "" {
 			return
 		}
+		if !utils.DiskspaceAvailable(len(inputStr), config.ClipseConfig.HistoryFilePath) {
+			utils.LogERROR("no available disk space to store text")
+			return
+		}
 		if err := config.AddClipboardItem(inputStr, "null"); err != nil {
 			utils.LogERROR(fmt.Sprintf("failed to add new item `( %s )` | %s", input, err))
 		}

--- a/utils/disk.go
+++ b/utils/disk.go
@@ -6,19 +6,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//path ex. config.ClipseConfig.HistoryFilePath, config.ClipseConfig.TempDirPath, defaults to "/"
+// path ex. config.ClipseConfig.HistoryFilePath, config.ClipseConfig.TempDirPath, defaults to "/"
 func DiskspaceAvailable(bytes int, path ...string) bool {
-    checkPath := "/"
-    if len(path) > 0 {
-        checkPath = path[0]
-    }
+	checkPath := "/"
+	if len(path) > 0 {
+		checkPath = path[0]
+	}
 
-    var stat unix.Statfs_t
-    if err := unix.Statfs(checkPath, &stat); err != nil {
-        LogERROR(fmt.Sprintf("failed to check disk space: %s", err))
-        return true
-    }
-    bytefree := stat.Bavail * uint64(stat.Bsize)
+	var stat unix.Statfs_t
+	if err := unix.Statfs(checkPath, &stat); err != nil {
+		LogERROR(fmt.Sprintf("failed to check disk space: %s", err))
+		return true
+	}
+	bytefree := stat.Bavail * uint64(stat.Bsize)
 
-    return bytefree > (uint64(bytes) * 2) // *2 for safety buffer
+	return bytefree > (uint64(bytes) * 2) // *2 for safety buffer
 }

--- a/utils/disk.go
+++ b/utils/disk.go
@@ -6,14 +6,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func DiskspaceAvailable(bytes int) bool {
-	var stat unix.Statfs_t
-	if err := unix.Statfs("/", &stat); err != nil {
-		LogERROR(fmt.Sprintf("failed to check disk space: %s", err))
-		return true
-	}
+//path ex. config.ClipseConfig.HistoryFilePath, config.ClipseConfig.TempDirPath, defaults to "/"
+func DiskspaceAvailable(bytes int, path ...string) bool {
+    checkPath := "/"
+    if len(path) > 0 {
+        checkPath = path[0]
+    }
 
-	bytefree := (stat.Bavail * uint64(stat.Bsize))
+    var stat unix.Statfs_t
+    if err := unix.Statfs(checkPath, &stat); err != nil {
+        LogERROR(fmt.Sprintf("failed to check disk space: %s", err))
+        return true
+    }
+    bytefree := stat.Bavail * uint64(stat.Bsize)
 
-	return bytefree > (uint64(bytes) * 2) // *2 for safety buffer
+    return bytefree > (uint64(bytes) * 2) // *2 for safety buffer
 }


### PR DESCRIPTION
I don't have any experience with Go, I tried my best, treat it more as of proof of concept how #348 could be fixed/or what could be causing issues.

While trying to fix it I also spotted that "/" is always used, instead of config values (I created limited size folder in mnt for testing purpose and I ran into it) so I added ability to check config path instead. My approach definitely can be improved, just didn't want to mess too much with your code.