### PR TITLE
fix: update Hyprland windowrule syntax for 0.53+

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ clipse -listen
 
   exec-once = clipse -listen # run listener on startup
 
-  windowrule = match:class clipse, float true # ensure you have a floating window class set if you want this behavior
-  windowrule = match:class clipse, size 622 652 # set the size of the window as necessary
+  windowrule = float on, match:class clipse # ensure you have a floating window class set if you want this behavior
+  windowrule = size 622 652, match:class clipse # set the size of the window as necessary
 
   bind = SUPER, V, exec,  <terminal name> --class clipse -e 'clipse'
 


### PR DESCRIPTION
Fixes #354

Updates the Hyprland windowrule examples to use the new syntax
required since Hyprland 0.53+.