### PR TITLE
fix(x11): use xclip for persistent clipboard ownership

### DIFF
--- a/display/x11.go
+++ b/display/x11.go
@@ -14,15 +14,11 @@ func (xds *XDS) Runtime() string {
 }
 
 func (xds *XDS) CopyText(text string) {
-	if err := shell.X11CopyText(text); err != nil {
-		handlers.X11SetClipboardText(text)
-	}
+	shell.X11CopyText(text)
 }
 
 func (xds *XDS) CopyImage(filePath string) {
-	if err := shell.X11CopyImage(filePath); err != nil {
-		handlers.X11SetClipboardImage(filePath)
-	}
+	shell.X11CopyImage(filePath)
 }
 
 func (xds *XDS) ReadClipboard() string {

--- a/display/x11.go
+++ b/display/x11.go
@@ -14,11 +14,15 @@ func (xds *XDS) Runtime() string {
 }
 
 func (xds *XDS) CopyText(text string) {
-	handlers.X11SetClipboardText(text)
+	if err := shell.X11CopyText(text); err != nil {
+		handlers.X11SetClipboardText(text)
+	}
 }
 
 func (xds *XDS) CopyImage(filePath string) {
-	handlers.X11SetClipboardImage(filePath)
+	if err := shell.X11CopyImage(filePath); err != nil {
+		handlers.X11SetClipboardImage(filePath)
+	}
 }
 
 func (xds *XDS) ReadClipboard() string {

--- a/handlers/x11.go
+++ b/handlers/x11.go
@@ -141,65 +141,73 @@ char* getClipboardTextX11() {
 unsigned char* getClipboardImageX11(int *out_len) {
     init_x11();
     if (!dpy) return NULL;
-
     *out_len = 0;
 
     Atom sel = XA_CLIPBOARD;
+    Atom TARGETS = XInternAtom(dpy, "TARGETS", False);
 
     // preferred MIME targets (BMP removed)
     Atom PNG  = XInternAtom(dpy, "image/png", False);
     Atom JPEG = XInternAtom(dpy, "image/jpeg", False);
 
-    Atom targets[] = { PNG, JPEG };
-    const int ntargets = sizeof(targets) / sizeof(targets[0]);
+    // First ask what formats are available
+    XConvertSelection(dpy, sel, TARGETS, TARGETS, win, CurrentTime);
+    XFlush(dpy);
 
-    for (int i = 0; i < ntargets; i++) {
-        Atom target = targets[i];
+    XEvent ev;
+    XNextEvent(dpy, &ev);
 
-        // Ask clipboard owner to convert to requested type
-        XConvertSelection(dpy, sel, target, target, win, CurrentTime);
-        XFlush(dpy);
+    if (ev.type != SelectionNotify || ev.xselection.property == None)
+        return NULL;
 
-        // Wait for the SelectionNotify event
-        XEvent ev;
-        XNextEvent(dpy, &ev);
+    Atom type;
+    int format;
+    unsigned long len, bytes_left;
+    unsigned char *data = NULL;
 
-        if (ev.type != SelectionNotify)
-            continue;
+    XGetWindowProperty(dpy, win, TARGETS, 0, ~0, False,
+                       AnyPropertyType, &type, &format,
+                       &len, &bytes_left, &data);
 
-        if (ev.xselection.property == None)
-            continue;
+    if (!data) return NULL;
 
-        Atom type;
-        int format;
-        unsigned long len, bytes_left;
-        unsigned char *data = NULL;
+    // Check if PNG or JPEG is in the supported targets
+    Atom *atoms = (Atom*)data;
+    Atom target = None;
+    for (unsigned long i = 0; i < len; i++) {
+        if (atoms[i] == PNG)  { target = PNG;  break; }
+        if (atoms[i] == JPEG) { target = JPEG; break; }
+    }
+    XFree(data);
 
-        if (XGetWindowProperty(dpy, win, target, 0, ~0, False,
-                               AnyPropertyType, &type, &format,
-                               &len, &bytes_left, &data) != Success) {
-            continue;
-        }
+    if (target == None) return NULL; // no image format available
 
-        if (!data || len == 0) {
-            if (data) XFree(data);
-            continue;
-        }
+    // Now request the actual image data
+    XConvertSelection(dpy, sel, target, target, win, CurrentTime);
+    XFlush(dpy);
 
-        // XGetWindowProperty returns len in terms of format units, not bytes
-        // format is in bits (8, 16, or 32), so calculate actual byte length
-        int actual_len = len * (format / 8);
+    XNextEvent(dpy, &ev);
+    if (ev.type != SelectionNotify || ev.xselection.property == None)
+        return NULL;
 
-        // Copy result to malloc'd buffer (Go will free this)
-        unsigned char *copy = malloc(actual_len);
-        memcpy(copy, data, actual_len);
-        XFree(data);
+    data = NULL;
+    if (XGetWindowProperty(dpy, win, target, 0, ~0, False,
+                           AnyPropertyType, &type, &format,
+                           &len, &bytes_left, &data) != Success)
+        return NULL;
 
-        *out_len = actual_len;
-        return copy;
+    if (!data || len == 0) {
+        if (data) XFree(data);
+        return NULL;
     }
 
-    return NULL; // neither PNG nor JPEG available
+    int actual_len = len * (format / 8);
+    unsigned char *copy = malloc(actual_len);
+    memcpy(copy, data, actual_len);
+    XFree(data);
+
+    *out_len = actual_len;
+    return copy;
 }
 
 // Clipboard data holder
@@ -333,6 +341,7 @@ int setClipboardImageX11(unsigned char *data, int len, const char *mime_type) {
 }
 */
 import "C"
+
 import (
 	"fmt"
 	"os"
@@ -372,6 +381,7 @@ func RunX11Listener() {
 
 			if imgContents != nil {
 				utils.HandleError(SaveImage(imgContents))
+				continue
 			}
 
 			// Check if the clipboard content should be excluded based on source application

--- a/shell/constants.go
+++ b/shell/constants.go
@@ -5,6 +5,7 @@ const (
 	listenShellCmd     = "--listen-shell"
 	pgrepCmd           = "pgrep 'clipse'"
 	psCmd              = "ps -o command"
+	x11CopyHandler     = "xclip"
 	wlCopyHandler      = "wl-copy"
 	wlPasteHandler     = "wl-paste"
 	wlPasteWatcher     = "--watch"

--- a/shell/x11.go
+++ b/shell/x11.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -22,6 +23,25 @@ func X11ActiveWindowTitle() string {
 	}
 	utils.LogWARN("Failed to get active window on X11: no suitable tool found (Xdotool, Xprop)")
 	return ""
+}
+
+func X11CopyText(text string) error {
+	cmd := exec.Command(x11CopyHandler, "-selection", "clipboard")
+	cmd.Stdin = strings.NewReader(text)
+	err := cmd.Run()
+	if err != nil {
+		utils.LogERROR(fmt.Sprintf("failed to copy text via xclip: %v", err))
+	}
+	return err
+}
+
+func X11CopyImage(filePath string) error {
+	cmd := exec.Command(x11CopyHandler, "-selection", "clipboard", "-t", "image/png", "-i", filePath)
+	err := cmd.Run()
+	if err != nil {
+		utils.LogERROR(fmt.Sprintf("failed to copy image via xclip: %v", err))
+	}
+	return err
 }
 
 // tryXprop tries getting the window title for X11 systems using xprop - property displayer for X

--- a/shell/x11.go
+++ b/shell/x11.go
@@ -1,9 +1,9 @@
 package shell
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/savedra1/clipse/utils"
 )
@@ -25,23 +25,20 @@ func X11ActiveWindowTitle() string {
 	return ""
 }
 
-func X11CopyText(text string) error {
+func X11CopyText(text string) {
 	cmd := exec.Command(x11CopyHandler, "-selection", "clipboard")
-	cmd.Stdin = strings.NewReader(text)
-	err := cmd.Run()
-	if err != nil {
-		utils.LogERROR(fmt.Sprintf("failed to copy text via xclip: %v", err))
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
 	}
-	return err
+
+	cmd.Stdin = strings.NewReader(text)
+	utils.HandleError(cmd.Start())
 }
 
-func X11CopyImage(filePath string) error {
+func X11CopyImage(filePath string) {
 	cmd := exec.Command(x11CopyHandler, "-selection", "clipboard", "-t", "image/png", "-i", filePath)
-	err := cmd.Run()
-	if err != nil {
-		utils.LogERROR(fmt.Sprintf("failed to copy image via xclip: %v", err))
-	}
-	return err
+	runDetachedCmd(cmd)
 }
 
 // tryXprop tries getting the window title for X11 systems using xprop - property displayer for X


### PR DESCRIPTION
## Description
In X11, the owning process must stay alive to serve SelectionRequest events. The previous native implementation held ownership for only 1 second before exiting, causing the clipboard to appear empty to other apps after the TUI closed.
Fixes #45 

## Changes
- Use xclip to copy text/images so ownership persists after TUI closes
- Check TARGETS atom before requesting image data to avoid xclip returning garbage bytes for unsupported formats

## Notes
`xclip` must be installed for X11 clipboard to work correctly. `xsel` could be impelmented the same way too except for images which are unsupported