### PR TITLE
Account current page for mouse motion

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -365,7 +365,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if msg.Y >= listItemsStart {
 				relativeY := msg.Y - listItemsStart
-				hoveredIndex := relativeY / linesPerItem
+				indexOnPage := relativeY / linesPerItem
+
+				page := m.list.Paginator.Page
+				perPage := m.list.Paginator.PerPage
+				hoveredIndex := page*perPage + indexOnPage
 
 				if hoveredIndex < len(m.list.Items()) {
 					if m.showConfirmation {


### PR DESCRIPTION
Mouse motion does not account page number so it always returns to first index on first page no matter what page is currently shown.

Fixes https://github.com/savedra1/clipse/issues/363