### PR TITLE
fix(wayland): allow selecting very long texts to paste

### DIFF
--- a/shell/wayland.go
+++ b/shell/wayland.go
@@ -19,7 +19,8 @@ func GetWLClipBoard() (string, error) {
 }
 
 func UpdateWLClipboard(s string) error {
-	cmd := exec.Command(wlCopyHandler, "--", s)
+	cmd := exec.Command(wlCopyHandler, "--")
+	cmd.Stdin = strings.NewReader(s)
 	if err := cmd.Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Selecting a very long text from the clipse clipboard (>=131072 characters on my system) would fail and produce the following log message:
`logger.go:21: ERROR: fork/exec /usr/bin/wl-copy: argument list too long`
Passing the string through stdin instead of as a command line argument avoids this issue.