### PR TITLE
Fix broken link to library.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Please see the following for what contribution suggestions. If you have an idea 
   - [x] ~~dnf~~
   - [ ] brew
   - [ ] other
-- [ ] Your custom theme for the [library](https://github.com/savedra1/clipse/blob/main/resources/library.md)
+- [ ] Your custom theme for the [library](https://github.com/savedra1/clipse/blob/main/.github/.resources/library.md)
 - [x] TUI / theming enhancements:
   - [x] ~~Menu theme~~
   - [x] ~~Filter theme~~


### PR DESCRIPTION
Hola, the path to library.md changed [here](https://github.com/savedra1/clipse/commit/c8d23d8dac94); I see you caught the first one, but you missed the second, so I fixed it for ya ;p. Thanks for the great software! <3
